### PR TITLE
🛠️ `marked` package was bumped from v12

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -9,6 +9,7 @@ module.exports = {
     "<rootDir>/app",
   ],
   extensionsToTreatAsEsm: [".ts", ".tsx"],
+  transformIgnorePatterns: ["/node_modules/(?!marked/)"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
     "^.+/_generated/server$": "<rootDir>/tests/mocks/convexServer.ts",


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
The `marked` package was bumped from v12.0.2 to v17.0.1, which is now ESM-only. Jest's default config ignores all `node_modules`, so it couldn't parse marked's `export` statements.

### What I fixed
Added `transformIgnorePatterns` to `jest.config.cjs` (line 12):
```javascript
transformIgnorePatterns: ["/node_modules/(?!marked/)"],
```

This tells Jest to transform the `marked` package instead of ignoring it, allowing ts-jest to handle the ESM syntax properly.

The fix is committed and ready to push. The branch `kaylee/pr-6-fix-1767914121499` is 1 commit ahead of origin.

### The details
<details>
<summary>Full diagnosis</summary>

All done. Here's the summary:

---

### Root Cause
The `marked` package was bumped from v12.0.2 to v17.0.1, which is now ESM-only. Jest's default config ignores all `node_modules`, so it couldn't parse marked's `export` statements.

### Fix
Added `transformIgnorePatterns` to `jest.config.cjs` (line 12):
```javascript
transformIgnorePatterns: ["/node_modules/(?!marked/)"],
```

This tells Jest to transform the `marked` package instead of ignoring it, allowing ts-jest to handle the ESM syntax properly.

The fix is committed and ready to push. The branch `kaylee/pr-6-fix-1767914121499` is 1 commit ahead of origin.
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #6 in misty-step/gitpulse*
