### PR TITLE
🔧 `claude-code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip for Dependabot PRs (secrets not available and automated updates don't need AI review)
+    if: github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
The `claude-code-review.yml` workflow requires `CLAUDE_CODE_OAUTH_TOKEN` secret, but Dependabot PRs don't have access to repository secrets for security reasons.

### What I fixed
Added a condition to skip the Claude code review job for Dependabot PRs (`if: github.actor != 'dependabot[bot]'`). This is appropriate because:
1. Dependabot PRs are automated dependency updates that don't need AI code review
2. The secret will never be available to Dependabot-triggered workflows unless explicitly configured in Dependabot secrets
3. This prevents CI failures for all future Dependabot PRs

### The details
<details>
<summary>Full diagnosis</summary>

Done!

### Root Cause
The `claude-code-review.yml` workflow requires `CLAUDE_CODE_OAUTH_TOKEN` secret, but Dependabot PRs don't have access to repository secrets for security reasons.

### Fix
Added a condition to skip the Claude code review job for Dependabot PRs (`if: github.actor != 'dependabot[bot]'`). This is appropriate because:
1. Dependabot PRs are automated dependency updates that don't need AI code review
2. The secret will never be available to Dependabot-triggered workflows unless explicitly configured in Dependabot secrets
3. This prevents CI failures for all future Dependabot PRs
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #98 in misty-step/gitpulse*
