### PR TITLE
feat(analytics): add funnel event tracking for launch metrics

### DIFF
--- a/app/dashboard/reports/[id]/page.tsx
+++ b/app/dashboard/reports/[id]/page.tsx
@@ -4,8 +4,9 @@ import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import Link from "next/link";
+import { trackOnce } from "@/lib/analytics";
 import { useAuthenticatedConvexUser } from "@/hooks/useAuthenticatedConvexUser";
 import { useIntegrationStatus } from "@/hooks/useIntegrationStatus";
 import { IntegrationStatusBanner } from "@/components/IntegrationStatusBanner";
@@ -48,6 +49,18 @@ export default function ReportViewerPage() {
         idx < allReports.length - 1 ? allReports[idx + 1]._id : null,
     };
   }, [allReports, reportId]);
+
+  // Track first_report_viewed once when report loads
+  const hasTrackedView = useRef(false);
+  useEffect(() => {
+    if (report && !hasTrackedView.current) {
+      trackOnce("first_report_viewed", {
+        reportId: report._id,
+        reportKind: report.scheduleType ?? "daily",
+      });
+      hasTrackedView.current = true;
+    }
+  }, [report]);
 
   // Keyboard shortcuts: Escape, ←, →
   useEffect(() => {

--- a/app/dashboard/reports/[id]/page.tsx
+++ b/app/dashboard/reports/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo } from "react";
 import Link from "next/link";
 import { trackOnce } from "@/lib/analytics";
 import { useAuthenticatedConvexUser } from "@/hooks/useAuthenticatedConvexUser";
@@ -50,15 +50,13 @@ export default function ReportViewerPage() {
     };
   }, [allReports, reportId]);
 
-  // Track first_report_viewed once when report loads
-  const hasTrackedView = useRef(false);
+  // Track first_report_viewed when report loads (trackOnce handles deduplication)
   useEffect(() => {
-    if (report && !hasTrackedView.current) {
+    if (report) {
       trackOnce("first_report_viewed", {
         reportId: report._id,
         reportKind: report.scheduleType ?? "daily",
       });
-      hasTrackedView.current = true;
     }
   }, [report]);
 

--- a/app/dashboard/reports/page.tsx
+++ b/app/dashboard/reports/page.tsx
@@ -12,6 +12,7 @@ import { IntegrationStatusBanner } from "@/components/IntegrationStatusBanner";
 import { getGithubInstallUrl, formatTimestamp } from "@/lib/integrationStatus";
 import type { IntegrationStatus } from "@/lib/integrationStatus";
 import { track } from "@vercel/analytics";
+import { trackFunnel } from "@/lib/analytics";
 import { toast } from "sonner";
 
 export default function ReportsPage() {
@@ -165,6 +166,10 @@ export default function ReportsPage() {
       if (result.success) {
         const { reportsGenerated, daysSkipped, daysWithoutEvents } = result;
         if (reportsGenerated > 0) {
+          trackFunnel("report_generated", {
+            reportKind: "daily",
+            count: reportsGenerated,
+          });
           toast.success(`Generated ${reportsGenerated} report${reportsGenerated > 1 ? "s" : ""}`);
         } else if (daysSkipped === 7) {
           toast.info("All days already have reports");
@@ -193,6 +198,12 @@ export default function ReportsPage() {
 
       if (result.success) {
         const { reportsGenerated, reportsDeleted } = result;
+        if (reportsGenerated > 0) {
+          trackFunnel("report_generated", {
+            reportKind: "daily",
+            count: reportsGenerated,
+          });
+        }
         toast.success(
           `Regenerated ${reportsGenerated} report${reportsGenerated !== 1 ? "s" : ""} (deleted ${reportsDeleted})`
         );

--- a/app/dashboard/settings/repositories/page.tsx
+++ b/app/dashboard/settings/repositories/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useAction, usePaginatedQuery, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { handleConvexError, showSuccess } from "@/lib/errors";
@@ -27,14 +27,12 @@ export default function RepositoriesPage() {
   const installations = useQuery(api.installations.listMyInstallations);
   const startBackfill = useAction(api.actions.startBackfill.startBackfill);
 
-  // Track first_sync_completed when repos first appear
-  const hasTrackedSync = useRef(false);
+  // Track first_sync_completed when repos appear (trackOnce handles deduplication)
   useEffect(() => {
-    if (repos.length > 0 && !hasTrackedSync.current) {
+    if (repos.length > 0) {
       trackOnce("first_sync_completed", {
-        repoCount: repos.length,
+        count: repos.length,
       });
-      hasTrackedSync.current = true;
     }
   }, [repos.length]);
 

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useRouter } from "next/navigation";
@@ -39,22 +39,18 @@ export default function OnboardingPage() {
     }
   }, [convexUser, timezone]);
 
-  // Track signup_completed when convexUser is first created
-  const hasTrackedSignup = useRef(false);
+  // Track signup_completed when convexUser exists (trackOnce handles deduplication)
   useEffect(() => {
-    if (convexUser && !hasTrackedSignup.current) {
-      trackOnce("signup_completed", { clerkUserId: clerkUser?.id ?? "" });
-      hasTrackedSignup.current = true;
+    if (convexUser && clerkUser?.id) {
+      trackOnce("signup_completed", { clerkUserId: clerkUser.id });
     }
   }, [convexUser, clerkUser?.id]);
 
-  // Track github_install_completed when connection becomes true
-  const prevGitHubConnected = useRef(false);
+  // Track github_install_completed when connected (trackOnce handles deduplication)
   useEffect(() => {
-    if (isGitHubConnected && !prevGitHubConnected.current) {
+    if (isGitHubConnected) {
       trackOnce("github_install_completed");
     }
-    prevGitHubConnected.current = isGitHubConnected;
   }, [isGitHubConnected]);
 
   // Redirect if already completed onboarding

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { Footer } from "@/components/Footer";
 import { HeroMetadata } from "@/components/HeroMetadata";
+import { trackFunnel } from "@/lib/analytics";
 
 const features = [
   {
@@ -52,6 +53,7 @@ export default function Home() {
             </Link>
             <Link
               href="/sign-up"
+              onClick={() => trackFunnel("signup_started", { source: "nav" })}
               className="rounded-full bg-foreground px-4 py-1.5 text-background transition-transform hover:scale-105 active:scale-95"
             >
               Get Started
@@ -80,6 +82,7 @@ export default function Home() {
                 <div className="mt-10 flex flex-wrap gap-4">
                   <Link
                     href="/sign-up"
+                    onClick={() => trackFunnel("signup_started", { source: "hero" })}
                     className="inline-flex h-12 items-center justify-center rounded-full bg-foreground px-8 text-sm font-semibold text-background transition-transform hover:-translate-y-1"
                   >
                     Start Integration

--- a/lib/__tests__/analytics.test.ts
+++ b/lib/__tests__/analytics.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for analytics utility functions.
+ *
+ * @jest-environment jsdom
+ */
+import { trackFunnel, trackOnce, FunnelEvent } from "../analytics";
+
+// Mock Vercel Analytics track function
+jest.mock("@vercel/analytics", () => ({
+  track: jest.fn(),
+}));
+
+import { track } from "@vercel/analytics";
+
+const mockTrack = track as jest.MockedFunction<typeof track>;
+
+describe("analytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Clear localStorage before each test
+    localStorage.clear();
+  });
+
+  describe("trackFunnel", () => {
+    it("calls track with event name", () => {
+      trackFunnel("signup_started");
+      expect(mockTrack).toHaveBeenCalledWith("signup_started", undefined);
+    });
+
+    it("calls track with event name and properties", () => {
+      trackFunnel("signup_started", { source: "hero" });
+      expect(mockTrack).toHaveBeenCalledWith("signup_started", {
+        source: "hero",
+      });
+    });
+  });
+
+  describe("trackOnce", () => {
+    it("tracks event on first call", () => {
+      trackOnce("first_report_viewed", { reportId: "123" });
+      expect(mockTrack).toHaveBeenCalledWith("first_report_viewed", {
+        reportId: "123",
+      });
+    });
+
+    it("stores tracking key in localStorage", () => {
+      trackOnce("first_sync_completed");
+      expect(localStorage.getItem("gitpulse_tracked_first_sync_completed")).not.toBeNull();
+    });
+
+    it("does not track same event twice", () => {
+      trackOnce("signup_completed");
+      trackOnce("signup_completed");
+      expect(mockTrack).toHaveBeenCalledTimes(1);
+    });
+
+    it("tracks different events independently", () => {
+      trackOnce("signup_completed");
+      trackOnce("github_install_completed");
+      expect(mockTrack).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("FunnelEvent type", () => {
+    it("accepts all valid funnel events", () => {
+      const validEvents: FunnelEvent[] = [
+        "signup_started",
+        "signup_completed",
+        "github_install_started",
+        "github_install_completed",
+        "first_sync_completed",
+        "first_report_viewed",
+        "report_generated",
+      ];
+
+      expect(validEvents).toHaveLength(7);
+    });
+  });
+});

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,39 @@
+/**
+ * Centralized analytics utility for funnel tracking.
+ *
+ * Uses Vercel Analytics track() with typed event names.
+ * Provides `trackOnce` for deduplication of one-time events.
+ */
+import { track } from "@vercel/analytics";
+
+export type FunnelEvent =
+  | "signup_started"
+  | "signup_completed"
+  | "github_install_started"
+  | "github_install_completed"
+  | "first_sync_completed"
+  | "first_report_viewed"
+  | "report_generated";
+
+type EventProperties = Record<string, string | number | boolean>;
+
+/**
+ * Track a funnel event with optional properties.
+ */
+export function trackFunnel(event: FunnelEvent, properties?: EventProperties) {
+  track(event, properties);
+}
+
+/**
+ * Track a one-time event using localStorage deduplication.
+ * Useful for "first" events that should only fire once per user.
+ */
+export function trackOnce(event: FunnelEvent, properties?: EventProperties) {
+  if (typeof window === "undefined") return;
+
+  const key = `gitpulse_tracked_${event}`;
+  if (!localStorage.getItem(key)) {
+    track(event, properties);
+    localStorage.setItem(key, Date.now().toString());
+  }
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -15,7 +15,7 @@ export type FunnelEvent =
   | "first_report_viewed"
   | "report_generated";
 
-type EventProperties = Record<string, string | number | boolean>;
+type EventProperties = Record<string, string | number | boolean | null>;
 
 /**
  * Track a funnel event with optional properties.


### PR DESCRIPTION
## Summary
- Add 7 key funnel events to track user journey: landing → signup → GitHub install → first sync → first report
- Create `lib/analytics.ts` with `trackFunnel` and `trackOnce` utilities
- `trackOnce` uses localStorage deduplication for one-time events

## Events Added
| Event | Location | Trigger |
|-------|----------|---------|
| `signup_started` | Landing page | Click "Get Started" / "Start Integration" |
| `signup_completed` | Onboarding | When convexUser is created |
| `github_install_started` | Onboarding | Click "Connect GitHub Account" |
| `github_install_completed` | Onboarding | When OAuth completes |
| `first_sync_completed` | Repositories page | When repos first appear |
| `first_report_viewed` | Report detail page | First report opened |
| `report_generated` | Reports page | Manual report generation |

## Test plan
- [x] TypeScript compiles (`pnpm typecheck`)
- [x] ESLint passes (`pnpm lint`)
- [x] All tests pass (602 tests including 7 new analytics tests)
- [ ] Manual verification: Check Vercel Analytics dashboard for events after deployment

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking for signup starts, GitHub install starts/completions, report generation and first report views, and repository sync completion.
  * Implemented a one-time tracking mechanism to avoid duplicate event recordings.

* **Tests**
  * Added test suite validating analytics event sending and one-time deduplication behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->