### PR TITLE
fix(observability): address high-priority logging gaps

### DIFF
--- a/convex/lib/__tests__/github.test.ts
+++ b/convex/lib/__tests__/github.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, it, jest, beforeEach, afterEach } from "@jest/globals";
+import {
+  describe,
+  expect,
+  it,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
 import {
   backfillPRs,
   listReviews,
@@ -8,7 +15,10 @@ import {
   listOrgRepositories,
   RateLimitError,
 } from "../github";
-import { createMockResponse, createMockErrorResponse } from "../../../tests/utils/factories";
+import {
+  createMockResponse,
+  createMockErrorResponse,
+} from "../../../tests/utils/factories";
 
 // Type for fetch mock that properly types parameters for toHaveBeenCalledWith assertions
 type FetchMock = jest.Mock<
@@ -140,11 +150,16 @@ describe("githubFetch - rate limit handling", () => {
 
   it("throws standard error for 403 without rate limit indicators", async () => {
     // Mock a 403 error that is NOT a rate limit (e.g., insufficient permissions)
+    // IMPORTANT: Must include .text() method since githubFetch calls response.text() first
     const mockFetch = jest.fn(() =>
       Promise.resolve({
         ok: false,
         status: 403,
         statusText: "Forbidden",
+        text: async () =>
+          JSON.stringify({
+            message: "Resource not accessible by integration",
+          }),
         json: async () => ({
           message: "Resource not accessible by integration",
         }),
@@ -355,9 +370,13 @@ describe("listCommits", () => {
     const mockFetch = jest.fn(() => {
       callCount++;
       if (callCount === 1) {
-        return createMockResponse(Array.from({ length: 100 }, (_, i) => ({ sha: `sha${i}` })));
+        return createMockResponse(
+          Array.from({ length: 100 }, (_, i) => ({ sha: `sha${i}` })),
+        );
       }
-      return createMockResponse(Array.from({ length: 25 }, (_, i) => ({ sha: `sha${i + 100}` })));
+      return createMockResponse(
+        Array.from({ length: 25 }, (_, i) => ({ sha: `sha${i + 100}` })),
+      );
     });
     global.fetch = mockFetch as any;
 
@@ -378,9 +397,13 @@ describe("listUserRepositories and listOrgRepositories", () => {
     const mockFetch = jest.fn(() => {
       callCount++;
       if (callCount === 1) {
-        return createMockResponse(Array.from({ length: 100 }, (_, i) => ({ id: i })));
+        return createMockResponse(
+          Array.from({ length: 100 }, (_, i) => ({ id: i })),
+        );
       }
-      return createMockResponse(Array.from({ length: 10 }, (_, i) => ({ id: i + 100 })));
+      return createMockResponse(
+        Array.from({ length: 10 }, (_, i) => ({ id: i + 100 })),
+      );
     });
     global.fetch = mockFetch as any;
 

--- a/convex/lib/github.ts
+++ b/convex/lib/github.ts
@@ -51,7 +51,7 @@ async function withRetry<T>(
       // Don't retry on final attempt
       if (attempt === maxRetries) {
         logger.warn(
-          { attempt, maxRetries, error: lastError.message },
+          { attempt, maxRetries, err: lastError },
           "GitHub API max retries exhausted",
         );
         break;
@@ -73,7 +73,7 @@ async function withRetry<T>(
         // Otherwise, if it's a short wait (e.g. secondary rate limit), wait and retry
         const delay = Math.max(baseDelay * Math.pow(2, attempt), 1000);
         logger.info(
-          { attempt, delayMs: delay, error: error.message },
+          { attempt, delayMs: delay, err: error },
           "GitHub API rate limit, retrying after delay",
         );
         await new Promise((resolve) => setTimeout(resolve, delay));
@@ -88,7 +88,7 @@ async function withRetry<T>(
       if (is403Or429) {
         const delay = baseDelay * Math.pow(2, attempt);
         logger.info(
-          { attempt, delayMs: delay, error: (error as Error).message },
+          { attempt, delayMs: delay, err: error },
           "GitHub API 403/429 error, retrying after delay",
         );
         await new Promise((resolve) => setTimeout(resolve, delay));
@@ -137,7 +137,7 @@ async function githubFetch<T>(
       } catch (e) {
         // Log when JSON parse fails - may contain useful debug info
         logger.warn(
-          { status: response.status, rawText: rawText?.slice(0, 500) },
+          { err: e, status: response.status, rawText: rawText?.slice(0, 500) },
           "Failed to parse GitHub error response as JSON",
         );
       }

--- a/convex/lib/github.ts
+++ b/convex/lib/github.ts
@@ -7,6 +7,8 @@
  * Deep module: Simple interface hiding GitHub API pagination, auth, rate limits.
  */
 
+import { logger } from "./logger";
+
 /**
  * GitHub API base URL
  */
@@ -48,6 +50,10 @@ async function withRetry<T>(
 
       // Don't retry on final attempt
       if (attempt === maxRetries) {
+        logger.warn(
+          { attempt, maxRetries, error: lastError.message },
+          "GitHub API max retries exhausted",
+        );
         break;
       }
 
@@ -57,11 +63,19 @@ async function withRetry<T>(
         // Let it throw so the caller can schedule a long-term pause
         const waitTime = error.reset - Date.now();
         if (waitTime > 60 * 1000) {
+          logger.warn(
+            { resetMs: waitTime, resetAt: new Date(error.reset).toISOString() },
+            "GitHub rate limit exceeded, long wait required",
+          );
           throw error;
         }
 
         // Otherwise, if it's a short wait (e.g. secondary rate limit), wait and retry
         const delay = Math.max(baseDelay * Math.pow(2, attempt), 1000);
+        logger.info(
+          { attempt, delayMs: delay, error: error.message },
+          "GitHub API rate limit, retrying after delay",
+        );
         await new Promise((resolve) => setTimeout(resolve, delay));
         continue;
       }
@@ -73,6 +87,10 @@ async function withRetry<T>(
 
       if (is403Or429) {
         const delay = baseDelay * Math.pow(2, attempt);
+        logger.info(
+          { attempt, delayMs: delay, error: (error as Error).message },
+          "GitHub API 403/429 error, retrying after delay",
+        );
         await new Promise((resolve) => setTimeout(resolve, delay));
       } else {
         // For other errors, throw immediately
@@ -111,11 +129,17 @@ async function githubFetch<T>(
       // Parse error body first to check message
       let message = "GitHub API rate limit exceeded";
       let errorBody: GitHubError | null = null;
+      let rawText: string | undefined;
       try {
-        errorBody = (await response.json()) as GitHubError;
+        rawText = await response.text();
+        errorBody = JSON.parse(rawText) as GitHubError;
         message = errorBody.message;
       } catch (e) {
-        // ignore json parse error
+        // Log when JSON parse fails - may contain useful debug info
+        logger.warn(
+          { status: response.status, rawText: rawText?.slice(0, 500) },
+          "Failed to parse GitHub error response as JSON",
+        );
       }
 
       const remainingHeader = response.headers.get("x-ratelimit-remaining");
@@ -137,6 +161,16 @@ async function githubFetch<T>(
         } else if (retryAfterHeader) {
           reset = Date.now() + parseInt(retryAfterHeader, 10) * 1000;
         }
+
+        logger.warn(
+          {
+            status: response.status,
+            remaining: remainingHeader,
+            resetAt: new Date(reset).toISOString(),
+            message,
+          },
+          "GitHub API rate limit hit",
+        );
 
         throw new RateLimitError(
           reset,

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,8 @@ import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Exclude pino from bundling - it uses worker threads that Turbopack can't handle
+  serverExternalPackages: ["pino", "pino-pretty", "thread-stream"],
 };
 
 export default withSentryConfig(nextConfig, {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "concurrently": "^9.2.1",
     "eslint": "^9",
     "eslint-config-next": "16.0.1",
+    "hono": "4.11.5",
     "import-in-the-middle": "^2.0.0",
     "jest": "29",
     "jest-environment-jsdom": "^30.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       eslint-config-next:
         specifier: 16.0.1
         version: 16.0.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      hono:
+        specifier: 4.11.5
+        version: 4.11.5
       import-in-the-middle:
         specifier: ^2.0.0
         version: 2.0.0
@@ -145,7 +148,7 @@ importers:
         version: 3.6.2
       promptfoo:
         specifier: ^0.120.10
-        version: 0.120.10(@types/json-schema@7.0.15)(@types/node@20.19.24)(@types/pg@8.15.6)(hono@4.11.3)(pg@8.16.3)(playwright-core@1.57.0)(socks@2.8.7)
+        version: 0.120.10(@types/json-schema@7.0.15)(@types/node@20.19.24)(@types/pg@8.15.6)(hono@4.11.5)(pg@8.16.3)(playwright-core@1.57.0)(socks@2.8.7)
       require-in-the-middle:
         specifier: ^8.0.1
         version: 8.0.1
@@ -5190,8 +5193,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.11.3:
-    resolution: {integrity: sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==}
+  hono@4.11.5:
+    resolution: {integrity: sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==}
     engines: {node: '>=16.9.0'}
 
   hookified@1.14.0:
@@ -10002,9 +10005,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@hono/node-server@1.19.7(hono@4.11.3)':
+  '@hono/node-server@1.19.7(hono@4.11.5)':
     dependencies:
-      hono: 4.11.3
+      hono: 4.11.5
 
   '@humanfs/core@0.19.1': {}
 
@@ -10603,9 +10606,9 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.25.2(hono@4.11.5)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.7(hono@4.11.3)
+      '@hono/node-server': 1.19.7(hono@4.11.5)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -10728,12 +10731,12 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@openai/agents-core@0.3.4(hono@4.11.3)(ws@8.18.3)(zod@3.25.76)':
+  '@openai/agents-core@0.3.4(hono@4.11.5)(ws@8.18.3)(zod@3.25.76)':
     dependencies:
       debug: 4.4.3
       openai: 6.15.0(ws@8.18.3)(zod@3.25.76)
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.5)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -10741,9 +10744,9 @@ snapshots:
       - supports-color
       - ws
 
-  '@openai/agents-openai@0.3.4(hono@4.11.3)(ws@8.18.3)(zod@3.25.76)':
+  '@openai/agents-openai@0.3.4(hono@4.11.5)(ws@8.18.3)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.4(hono@4.11.3)(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-core': 0.3.4(hono@4.11.5)(ws@8.18.3)(zod@3.25.76)
       debug: 4.4.3
       openai: 6.15.0(ws@8.18.3)(zod@3.25.76)
       zod: 3.25.76
@@ -10753,9 +10756,9 @@ snapshots:
       - supports-color
       - ws
 
-  '@openai/agents-realtime@0.3.4(hono@4.11.3)(zod@3.25.76)':
+  '@openai/agents-realtime@0.3.4(hono@4.11.5)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.4(hono@4.11.3)(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-core': 0.3.4(hono@4.11.5)(ws@8.18.3)(zod@3.25.76)
       '@types/ws': 8.18.1
       debug: 4.4.3
       ws: 8.18.3
@@ -10767,11 +10770,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@openai/agents@0.3.4(hono@4.11.3)(ws@8.18.3)(zod@3.25.76)':
+  '@openai/agents@0.3.4(hono@4.11.5)(ws@8.18.3)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.4(hono@4.11.3)(ws@8.18.3)(zod@3.25.76)
-      '@openai/agents-openai': 0.3.4(hono@4.11.3)(ws@8.18.3)(zod@3.25.76)
-      '@openai/agents-realtime': 0.3.4(hono@4.11.3)(zod@3.25.76)
+      '@openai/agents-core': 0.3.4(hono@4.11.5)(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-openai': 0.3.4(hono@4.11.5)(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-realtime': 0.3.4(hono@4.11.5)(zod@3.25.76)
       debug: 4.4.3
       openai: 6.15.0(ws@8.18.3)(zod@3.25.76)
       zod: 3.25.76
@@ -14606,7 +14609,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.11.3: {}
+  hono@4.11.5: {}
 
   hookified@1.14.0: {}
 
@@ -16580,7 +16583,7 @@ snapshots:
 
   progress@2.0.3: {}
 
-  promptfoo@0.120.10(@types/json-schema@7.0.15)(@types/node@20.19.24)(@types/pg@8.15.6)(hono@4.11.3)(pg@8.16.3)(playwright-core@1.57.0)(socks@2.8.7):
+  promptfoo@0.120.10(@types/json-schema@7.0.15)(@types/node@20.19.24)(@types/pg@8.15.6)(hono@4.11.5)(pg@8.16.3)(playwright-core@1.57.0)(socks@2.8.7):
     dependencies:
       '@anthropic-ai/sdk': 0.71.2(zod@3.25.76)
       '@apidevtools/json-schema-ref-parser': 15.1.3(@types/json-schema@7.0.15)
@@ -16591,8 +16594,8 @@ snapshots:
       '@inquirer/editor': 5.0.2(@types/node@20.19.24)
       '@inquirer/input': 5.0.2(@types/node@20.19.24)
       '@inquirer/select': 5.0.2(@types/node@20.19.24)
-      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@3.25.76)
-      '@openai/agents': 0.3.4(hono@4.11.3)(ws@8.18.3)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.5)(zod@3.25.76)
+      '@openai/agents': 0.3.4(hono@4.11.5)(ws@8.18.3)(zod@3.25.76)
       '@opencode-ai/sdk': 1.1.6
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
## Summary

Addresses high-priority items from the observability audit by adding structured logging to critical code paths that previously had no visibility.

### Changes

**GitHub API Client** (`convex/lib/github.ts`)
- Log retry attempts with delay duration and error context
- Log rate limit errors with reset time for debugging
- Log when JSON parsing fails for error responses (captures raw response text)

**Embedding Batch Handler** (`convex/actions/embeddings/ensureBatch.ts`)
- Log batch start with size and event IDs for traceability
- Log successful completion
- Log failures with full context (error, batch size, event IDs) before re-throwing

## Test plan

- [x] TypeScript compiles without errors
- [x] ESLint passes
- [ ] Deploy to preview and verify logs appear in Convex dashboard
- [ ] Trigger a GitHub API retry scenario and verify retry logs
- [ ] Trigger an embedding batch and verify start/complete logs

## Context

This is part of the observability improvements. Previous commits on `master` addressed:
- Structured logger for Next.js routes
- Migrating webhook/OAuth routes from console.* to logger
- Expanding health checks with external service monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved logging across background embedding processing and GitHub API interactions; excluded select packages from Next.js bundling; added a new runtime dependency.

* **New Features / Improvements**
  * Health endpoint deep mode now returns structured per-service statuses, treats POST/HEAD like GET, includes no-cache headers, and better indicates degraded/unconfigured states.

* **Tests**
  * Expanded health endpoint test coverage for multi-service scenarios, timeouts, and edge cases; minor test formatting refinements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->