### PR TITLE
fix(security): convert updateUserId to internalMutation

### DIFF
--- a/convex/lib/logger.ts
+++ b/convex/lib/logger.ts
@@ -12,6 +12,8 @@ const REDACT_PATHS = [
   "githubEmail",
   "clerkId",
   "userId",
+  "oldUserId",
+  "newUserId",
   "ghLogin",
   "githubUsername",
 

--- a/convex/reports.ts
+++ b/convex/reports.ts
@@ -229,9 +229,12 @@ export const pruneDuplicates = internalMutation({
 });
 
 /**
- * Update report userId (for fixing test data)
+ * Internal: Update report userId (for data migration/maintenance only)
+ *
+ * Security: This is an internalMutation - only callable from server-side code.
+ * Previously was a public mutation which allowed unauthorized ownership transfer (IDOR).
  */
-export const updateUserId = mutation({
+export const updateUserId = internalMutation({
   args: {
     oldUserId: v.string(),
     newUserId: v.string(),
@@ -250,6 +253,15 @@ export const updateUserId = mutation({
       reports.map((report) =>
         ctx.db.patch(report._id, { userId: args.newUserId }),
       ),
+    );
+
+    logger.info(
+      {
+        oldUserId: args.oldUserId,
+        newUserId: args.newUserId,
+        count: updates.length,
+      },
+      "Migrated report ownership",
     );
 
     return {
@@ -488,4 +500,3 @@ export const cleanupDuplicates = internalMutation({
     return { deleted };
   },
 });
-

--- a/vision.md
+++ b/vision.md
@@ -1,0 +1,78 @@
+# Vision
+
+## One-Liner
+Transform activity data into organizational intelligence — know who knows what, surface risks, and make better personnel decisions.
+
+## North Star
+**Pulse**: A unified pipeline that ingests activity from everywhere people work (GitHub, Slack, email, Salesforce) and synthesizes it into "demonstrations of knowledge" — cited, verifiable evidence of what each person knows and can do. Executives see the roadmap, backlog, and team composition side-by-side, with AI-powered insights about skill gaps, personnel vulnerabilities, and optimal team structure.
+
+## Evolution Path
+
+### Phase 1: Individual Reports (Current)
+- Sync GitHub activity for individual developers
+- Generate daily standups and weekly retros automatically
+- Solve the "what did I actually do?" problem for ICs
+
+### Phase 2: Team Reports (Next)
+- Expand to team-level visibility
+- Customizable report templates: time ranges, contributors, repos, orgs
+- Scheduled reports: "Q1 summary for Alex, Jill, Bob across gateway and web repos"
+- B2B focus — help non-technical stakeholders understand engineering work
+- Support, product, and sales can track bug fixes and feature promises
+
+### Phase 3: Knowledge Graph (Medium-term)
+- Synthesize activity into understanding of *who knows what*
+- Query interface: "Who should handle this Rails issue?"
+- Expert routing: When someone asks a question, direct them to the right person
+- Work assignment: Suggest optimal assignees based on demonstrated expertise
+
+### Phase 4: Organizational Intelligence (Vision)
+- Surface personnel vulnerabilities: "Only one person knows Rails — you're exposed"
+- Upskill recommendations: "Sarah has transferable skills for this gap"
+- Recruiting suggestions: Find developers on GitHub with needed skills
+- Roadmap-aware: Align team capabilities with backlog requirements
+- Executive dashboard: Roadmap + Backlog + Team Composition + Risk Analysis
+
+### Phase 5: Pulse (Ultimate)
+- Multi-source ingestion: GitHub + Slack + email + Salesforce + more
+- Every interaction becomes a potential "demonstration of knowledge"
+- Citations for every capability claim — traceable evidence
+- Cross-functional: Beyond engineering to entire organization
+- Strategic workforce planning powered by actual activity data
+
+## Key Differentiators
+
+1. **Citation-backed trust**: Every claim links to a verifiable source. No hallucinations, no guessing.
+2. **Demonstrations of knowledge**: Activity isn't just logged — it's synthesized into evidence of capability.
+3. **Bridge the language gap**: Help non-technical stakeholders understand engineering work without speaking Greek.
+4. **Risk visibility**: Surface what's in people's heads — skill concentrations, bus factor, bottlenecks.
+5. **Activity-grounded**: Based on what people actually do, not self-reported skills or outdated resumes.
+
+## Target Users
+
+### Today
+- Individual contributors who lose track of their own work
+- Developers preparing for standups, retros, performance reviews
+
+### Next
+- Engineering managers wanting team visibility without micromanagement
+- Product managers tracking feature delivery and bug fix progress
+- Support teams needing visibility into engineering work
+
+### Vision
+- Executives making personnel and team composition decisions
+- HR/recruiting identifying skill gaps and finding candidates
+- Cross-functional leaders understanding organizational capability
+
+## Current Focus (Q1 2026)
+Ship a launchable B2C product that proves the core value:
+1. Polish onboarding (fix 24-hour time-to-value gap)
+2. Stripe integration for monetization
+3. Report sharing for viral growth
+4. Landing page that communicates the citation-backed trust angle
+
+Then validate B2B with team-level reports and templates.
+
+---
+*Last updated: 2026-01-25*
+*Updated during: /groom session*


### PR DESCRIPTION
## Summary
- Fixes IDOR vulnerability in `reports.updateUserId` mutation
- Converts from public `mutation` to `internalMutation`
- Adds structured logging for migration operations

## Problem
The `updateUserId` mutation was exposed as a public Convex mutation, allowing any authenticated user to transfer report ownership arbitrarily. This is a classic IDOR (Insecure Direct Object Reference) vulnerability.

## Solution
Convert to `internalMutation` so it can only be called from server-side code (other Convex actions/mutations), not from the client.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (607 tests)
- [x] Verified mutation is no longer in public API

Closes #123

---
🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted ownership-migration operation to server-side/internal use and added server-side logging of migration counts.
  * Expanded log redaction to cover migrated user identifiers to reduce leak risk.

* **Documentation**
  * Added a Vision document outlining mission, five-phase roadmap, key differentiators, target users, and Q1 2026 focus.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->