### PR TITLE
feat(security): add OAuth endpoint rate limiting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -648,6 +648,41 @@ pnpm build
 - 🚧 Embedding service optimization
 - 📋 Planned: Secret rotation, observability dashboards, Stripe integration
 
+## Infrastructure (Terraform)
+
+The `infrastructure/` directory contains Terraform configurations for Vercel and other cloud resources.
+
+### Conventions
+
+1. **Always use current provider versions** - Check the Terraform registry for the latest version before adding providers. Outdated versions miss security fixes.
+   ```hcl
+   # Check: https://registry.terraform.io/providers/vercel/vercel/latest
+   version = "~> 4.0"  # Not ~> 2.0
+   ```
+
+2. **Consolidate identical rules** - Use OR-ed `condition_group` blocks instead of duplicate rules with identical actions.
+   ```hcl
+   # Good: Single rule with OR-ed conditions
+   condition_group = [
+     { conditions = [{ type = "path", op = "eq", value = "/api/a" }] },
+     { conditions = [{ type = "path", op = "eq", value = "/api/b" }] }
+   ]
+   
+   # Bad: Two separate rules with identical actions
+   ```
+
+3. **Prefer precise matching** - Use `op = "eq"` over `op = "pre"` + `op = "neq"` combinations when targeting specific paths.
+
+### Applying Changes
+
+```bash
+cd infrastructure
+export VERCEL_API_TOKEN=your_token
+terraform init
+terraform plan    # Review changes
+terraform apply   # Apply to Vercel
+```
+
 ---
 
 **Philosophy**: Simplicity through deep modules. Every interface should be minimal; every implementation should hide complexity. Fight accumulating dependencies and obscurity with ruthless information hiding.

--- a/infrastructure/firewall.tf
+++ b/infrastructure/firewall.tf
@@ -24,48 +24,25 @@ resource "vercel_firewall_config" "oauth_rate_limits" {
   project_id = data.vercel_project.gitpulse.id
 
   rules {
-    # Rule 1: Rate limit OAuth initiation endpoint
     rule {
-      name        = "oauth-init-rate-limit"
-      description = "Rate limit OAuth initiation to prevent state exhaustion"
-      condition_group = [{
-        conditions = [
-          {
+      name        = "oauth-endpoints-rate-limit"
+      description = "Rate limit OAuth initiation and callback endpoints"
+      condition_group = [
+        {
+          conditions = [{
             type  = "path"
-            op    = "pre"  # starts with
+            op    = "eq"
             value = "/api/auth/github"
-          },
-          {
+          }]
+        },
+        {
+          conditions = [{
             type  = "path"
-            op    = "neq"  # not equals
+            op    = "eq"
             value = "/api/auth/github/callback"
-          }
-        ]
-      }]
-      action = {
-        action = "rate_limit"
-        rate_limit = {
-          limit  = 60
-          window = 60
-          keys   = ["ip"]
-          algo   = "fixed_window"
-          action = "deny"
+          }]
         }
-        action_duration = "1m"
-      }
-    }
-
-    # Rule 2: Rate limit OAuth callback endpoint
-    rule {
-      name        = "oauth-callback-rate-limit"
-      description = "Rate limit OAuth callback to prevent brute force"
-      condition_group = [{
-        conditions = [{
-          type  = "path"
-          op    = "eq"
-          value = "/api/auth/github/callback"
-        }]
-      }]
+      ]
       action = {
         action = "rate_limit"
         rate_limit = {

--- a/infrastructure/firewall.tf
+++ b/infrastructure/firewall.tf
@@ -1,0 +1,82 @@
+# Vercel Firewall Configuration for GitPulse
+# Addresses: https://github.com/misty-step/gitpulse/issues/124
+#
+# This configuration adds rate limiting to OAuth endpoints to prevent:
+# - OAuth state exhaustion attacks
+# - GitHub API quota abuse
+# - Brute force attacks on auth flow
+
+terraform {
+  required_providers {
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 2.0"
+    }
+  }
+}
+
+# Reference existing project (don't recreate)
+data "vercel_project" "gitpulse" {
+  name = "gitpulse"
+}
+
+resource "vercel_firewall_config" "oauth_rate_limits" {
+  project_id = data.vercel_project.gitpulse.id
+
+  rules {
+    # Rule 1: Rate limit OAuth initiation endpoint
+    rule {
+      name        = "oauth-init-rate-limit"
+      description = "Rate limit OAuth initiation to prevent state exhaustion"
+      condition_group = [{
+        conditions = [
+          {
+            type  = "path"
+            op    = "pre"  # starts with
+            value = "/api/auth/github"
+          },
+          {
+            type  = "path"
+            op    = "neq"  # not equals
+            value = "/api/auth/github/callback"
+          }
+        ]
+      }]
+      action = {
+        action = "rate_limit"
+        rate_limit = {
+          limit  = 60
+          window = 60
+          keys   = ["ip"]
+          algo   = "fixed_window"
+          action = "deny"
+        }
+        action_duration = "1m"
+      }
+    }
+
+    # Rule 2: Rate limit OAuth callback endpoint
+    rule {
+      name        = "oauth-callback-rate-limit"
+      description = "Rate limit OAuth callback to prevent brute force"
+      condition_group = [{
+        conditions = [{
+          type  = "path"
+          op    = "eq"
+          value = "/api/auth/github/callback"
+        }]
+      }]
+      action = {
+        action = "rate_limit"
+        rate_limit = {
+          limit  = 60
+          window = 60
+          keys   = ["ip"]
+          algo   = "fixed_window"
+          action = "deny"
+        }
+        action_duration = "1m"
+      }
+    }
+  }
+}

--- a/infrastructure/firewall.tf
+++ b/infrastructure/firewall.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     vercel = {
       source  = "vercel/vercel"
-      version = "~> 2.0"
+      version = "~> 4.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #124 - Missing rate limiting on OAuth endpoints.

This PR adds **Vercel WAF rate limiting** to protect OAuth endpoints from:
- OAuth state exhaustion attacks
- GitHub API quota abuse  
- Brute force attacks on auth flow

### Configuration

| Endpoint | Rate Limit | Action |
|----------|------------|--------|
| `/api/auth/github` | 60 req/min/IP | 429 + 1min block |
| `/api/auth/github/callback` | 60 req/min/IP | 429 + 1min block |

### Implementation Options

**Option A: Terraform (recommended for IaC)**
```bash
cd infrastructure
export VERCEL_API_TOKEN=your_token
terraform init && terraform apply
```

**Option B: Manual Dashboard**
1. Go to https://vercel.com/misty-step/gitpulse/firewall
2. Configure → + New Rule
3. Create rules per the Technical Design in issue comments

### Files Changed
- `infrastructure/firewall.tf` - Terraform config for Vercel WAF rules

### Test Plan
- [ ] Apply Terraform config OR configure via dashboard
- [ ] Test: `for i in {1..70}; do curl -s -o /dev/null -w "%{http_code}\n" https://gitpulse.app/api/auth/github; done`
- [ ] Verify: First 60 return 302, last 10 return 429
- [ ] Verify: Normal OAuth flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate limiting on OAuth authentication endpoints.
  * Enforced per-IP fixed-window limits (60 requests per 60s) with automatic temporary blocking when exceeded.

* **Documentation**
  * Added an "Infrastructure (Terraform)" documentation section describing conventions and usage.
  * Note: the infrastructure section was inserted twice, resulting in duplicate content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->