### PR TITLE
feat(dashboard): add Yesterday widget for quick standup summary

### DIFF
--- a/app/dashboard/reports/page.tsx
+++ b/app/dashboard/reports/page.tsx
@@ -6,6 +6,7 @@ import type { Doc, Id } from "@/convex/_generated/dataModel";
 import Link from "next/link";
 import { useState, useRef, useEffect, useMemo, ReactNode } from "react";
 import { handleConvexError, showSuccess } from "@/lib/errors";
+import { formatReportDate } from "@/lib/formatters";
 import { useAuthenticatedConvexUser } from "@/hooks/useAuthenticatedConvexUser";
 import { useIntegrationStatus } from "@/hooks/useIntegrationStatus";
 import { IntegrationStatusBanner } from "@/components/IntegrationStatusBanner";
@@ -407,27 +408,6 @@ export default function ReportsPage() {
       )}
     </div>
   );
-}
-
-// ============================================================================
-// Helper Functions
-// ============================================================================
-
-function formatReportDate(startDate: number, endDate: number): string {
-  const start = new Date(startDate);
-  const end = new Date(endDate);
-
-  const sameDay = start.toDateString() === end.toDateString();
-
-  if (sameDay) {
-    return end.toLocaleDateString("en-US", {
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-    });
-  }
-
-  return `${start.toLocaleDateString("en-US", { month: "short", day: "numeric" })} – ${end.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`;
 }
 
 type ReportDiagnostic = {

--- a/app/dashboard/reports/page.tsx
+++ b/app/dashboard/reports/page.tsx
@@ -249,10 +249,7 @@ export default function ReportsPage() {
   return (
     <div className="max-w-4xl mx-auto space-y-6">
       <IntegrationStatusBanner />
-      <YesterdayWidget
-        reports={reports as Doc<"reports">[] | undefined}
-        isLoading={reports === undefined}
-      />
+      <YesterdayWidget reports={reports} isLoading={reports === undefined} />
 
       {/* Header */}
       <div className="flex items-center justify-between">

--- a/app/dashboard/reports/page.tsx
+++ b/app/dashboard/reports/page.tsx
@@ -2,13 +2,14 @@
 
 import { useQuery, useMutation, useAction } from "convex/react";
 import { api } from "@/convex/_generated/api";
-import { Id } from "@/convex/_generated/dataModel";
+import type { Doc, Id } from "@/convex/_generated/dataModel";
 import Link from "next/link";
 import { useState, useRef, useEffect, useMemo, ReactNode } from "react";
 import { handleConvexError, showSuccess } from "@/lib/errors";
 import { useAuthenticatedConvexUser } from "@/hooks/useAuthenticatedConvexUser";
 import { useIntegrationStatus } from "@/hooks/useIntegrationStatus";
 import { IntegrationStatusBanner } from "@/components/IntegrationStatusBanner";
+import { YesterdayWidget } from "@/components/YesterdayWidget";
 import { getGithubInstallUrl, formatTimestamp } from "@/lib/integrationStatus";
 import type { IntegrationStatus } from "@/lib/integrationStatus";
 import { trackEvent, trackFunnel } from "@/lib/analytics";
@@ -247,6 +248,10 @@ export default function ReportsPage() {
   return (
     <div className="max-w-4xl mx-auto space-y-6">
       <IntegrationStatusBanner />
+      <YesterdayWidget
+        reports={reports as Doc<"reports">[] | undefined}
+        isLoading={reports === undefined}
+      />
 
       {/* Header */}
       <div className="flex items-center justify-between">

--- a/components/YesterdayWidget.tsx
+++ b/components/YesterdayWidget.tsx
@@ -108,6 +108,7 @@ export function YesterdayWidget({ reports, isLoading }: YesterdayWidgetProps) {
 
       {isExpanded && (
         <div className="mt-6 border-t border-border/70 pt-6">
+          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via DOMPurify */}
           <div
             className="prose-luxury max-w-none"
             dangerouslySetInnerHTML={{

--- a/components/YesterdayWidget.tsx
+++ b/components/YesterdayWidget.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState } from "react";
+import type { Doc } from "@/convex/_generated/dataModel";
+import { trackEvent } from "@/lib/analytics";
+import DOMPurify from "isomorphic-dompurify";
+
+type YesterdayWidgetProps = {
+  reports: Doc<"reports">[] | undefined;
+  isLoading: boolean;
+};
+
+export function YesterdayWidget({ reports, isLoading }: YesterdayWidgetProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const dailyReport = reports?.filter(
+    (report) => report.scheduleType === "daily",
+  )[0];
+  const summaryBullets =
+    dailyReport?.sections?.[0]?.bullets?.filter((bullet) =>
+      Boolean(bullet?.trim()),
+    ) ?? [];
+  const tldrBullets = summaryBullets.slice(0, 3);
+
+  if (isLoading) {
+    return (
+      <div className="animate-pulse rounded-xl border border-border bg-surface p-6">
+        <div className="mb-4 h-3 w-28 rounded bg-surface-muted" />
+        <div className="mb-3 h-6 w-2/3 rounded bg-surface-muted" />
+        <div className="space-y-2">
+          <div className="h-3 w-full rounded bg-surface-muted" />
+          <div className="h-3 w-5/6 rounded bg-surface-muted" />
+          <div className="h-3 w-2/3 rounded bg-surface-muted" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!dailyReport) {
+    return (
+      <div className="rounded-xl border border-border bg-surface p-6">
+        <p className="text-sm font-semibold">No daily reports yet</p>
+        <p className="mt-2 text-sm text-muted">
+          Run your daily standup to see yesterday&apos;s summary here.
+        </p>
+      </div>
+    );
+  }
+
+  const formattedDate = formatReportDate(
+    dailyReport.startDate,
+    dailyReport.endDate,
+  );
+  const reportTitle = dailyReport.title || "Daily Standup";
+
+  const handleToggle = () => {
+    setIsExpanded((prev) => {
+      const next = !prev;
+      if (next) {
+        trackEvent("yesterday_widget_expanded", {
+          reportId: dailyReport._id,
+        });
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="rounded-xl border border-border bg-surface p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[10px] font-mono uppercase tracking-wider text-muted">
+              Yesterday
+            </span>
+            <span className="text-xs text-muted">{formattedDate}</span>
+          </div>
+          <h3 className="text-lg font-semibold text-foreground">
+            {reportTitle}
+          </h3>
+        </div>
+        <button
+          type="button"
+          onClick={handleToggle}
+          className="text-xs font-medium text-muted hover:text-foreground transition-colors"
+          aria-expanded={isExpanded}
+        >
+          {isExpanded ? "Collapse" : "Expand"}
+        </button>
+      </div>
+
+      <div className="mt-4">
+        <span className="text-[10px] font-mono uppercase tracking-wider text-muted">
+          TL;DR
+        </span>
+        {tldrBullets.length > 0 ? (
+          <ul className="mt-2 space-y-2 text-sm text-muted">
+            {tldrBullets.map((bullet, index) => (
+              <li
+                key={`${dailyReport._id}-tldr-${index}`}
+                className="flex gap-2"
+              >
+                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-muted-foreground/70" />
+                <span>{bullet}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-2 text-sm text-muted">
+            Summary bullets will appear after the next run.
+          </p>
+        )}
+      </div>
+
+      {isExpanded && (
+        <div className="mt-6 border-t border-border/70 pt-6">
+          <div
+            className="prose-luxury max-w-none"
+            dangerouslySetInnerHTML={{
+              __html: DOMPurify.sanitize(dailyReport.html ?? ""),
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatReportDate(startDate: number, endDate: number): string {
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+
+  const sameDay = start.toDateString() === end.toDateString();
+
+  if (sameDay) {
+    return end.toLocaleDateString("en-US", {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    });
+  }
+
+  return `${start.toLocaleDateString("en-US", { month: "short", day: "numeric" })} – ${end.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`;
+}

--- a/components/YesterdayWidget.tsx
+++ b/components/YesterdayWidget.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { Doc } from "@/convex/_generated/dataModel";
 import { trackEvent } from "@/lib/analytics";
+import { formatReportDate } from "@/lib/formatters";
 import DOMPurify from "isomorphic-dompurify";
 
 type YesterdayWidgetProps = {
@@ -117,21 +118,4 @@ export function YesterdayWidget({ reports, isLoading }: YesterdayWidgetProps) {
       )}
     </div>
   );
-}
-
-function formatReportDate(startDate: number, endDate: number): string {
-  const start = new Date(startDate);
-  const end = new Date(endDate);
-
-  const sameDay = start.toDateString() === end.toDateString();
-
-  if (sameDay) {
-    return end.toLocaleDateString("en-US", {
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-    });
-  }
-
-  return `${start.toLocaleDateString("en-US", { month: "short", day: "numeric" })} – ${end.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`;
 }

--- a/components/YesterdayWidget.tsx
+++ b/components/YesterdayWidget.tsx
@@ -12,13 +12,12 @@ type YesterdayWidgetProps = {
 
 export function YesterdayWidget({ reports, isLoading }: YesterdayWidgetProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const dailyReport = reports?.filter(
+  const dailyReport = reports?.find(
     (report) => report.scheduleType === "daily",
-  )[0];
+  );
   const summaryBullets =
-    dailyReport?.sections?.[0]?.bullets?.filter((bullet) =>
-      Boolean(bullet?.trim()),
-    ) ?? [];
+    dailyReport?.sections?.[0]?.bullets?.filter((bullet) => bullet?.trim()) ??
+    [];
   const tldrBullets = summaryBullets.slice(0, 3);
 
   if (isLoading) {
@@ -53,15 +52,10 @@ export function YesterdayWidget({ reports, isLoading }: YesterdayWidgetProps) {
   const reportTitle = dailyReport.title || "Daily Standup";
 
   const handleToggle = () => {
-    setIsExpanded((prev) => {
-      const next = !prev;
-      if (next) {
-        trackEvent("yesterday_widget_expanded", {
-          reportId: dailyReport._id,
-        });
-      }
-      return next;
-    });
+    if (!isExpanded) {
+      trackEvent("yesterday_widget_expanded", { reportId: dailyReport._id });
+    }
+    setIsExpanded(!isExpanded);
   };
 
   return (

--- a/components/YesterdayWidget.tsx
+++ b/components/YesterdayWidget.tsx
@@ -101,7 +101,7 @@ export function YesterdayWidget({ reports, isLoading }: YesterdayWidgetProps) {
           </ul>
         ) : (
           <p className="mt-2 text-sm text-muted">
-            Summary bullets will appear after the next run.
+            Expand to read your full report.
           </p>
         )}
       </div>

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -1,0 +1,16 @@
+export function formatReportDate(startDate: number, endDate: number): string {
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+
+  const sameDay = start.toDateString() === end.toDateString();
+
+  if (sameDay) {
+    return end.toLocaleDateString("en-US", {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    });
+  }
+
+  return `${start.toLocaleDateString("en-US", { month: "short", day: "numeric" })} – ${end.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`;
+}


### PR DESCRIPTION
## Summary

Adds a "Yesterday" widget to the dashboard that displays the most recent daily report summary at a glance, solving the #1 use case: preparing for standup.

- **Hero position**: Widget appears above report list, first thing users see
- **TL;DR format**: Shows title + first 3 bullets from the report
- **Inline expand**: Click to see full report without navigation
- **Zero new API calls**: Filters existing reports query client-side
- **Analytics tracking**: Tracks expand events for engagement metrics

Closes #93

## Changes

| File | Change |
|------|--------|
| `components/YesterdayWidget.tsx` | New widget component with loading, empty, collapsed, and expanded states |
| `app/dashboard/reports/page.tsx` | Integration - renders widget after status banner |
| `lib/formatters.ts` | Extracted shared date formatting utility (eliminates duplication) |

## Test plan

- [ ] Widget appears above report list on dashboard
- [ ] Shows most recent daily report (not weekly)
- [ ] On Monday, shows Friday's report if no weekend activity
- [ ] Empty state displays when no daily reports exist
- [ ] Expand/collapse works without page navigation
- [ ] Mobile responsive - no layout break
- [ ] PostHog receives `yesterday_widget_expanded` event on expand

## Screenshots

_Manual verification recommended - run `pnpm dev` and check dashboard_

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Yesterday widget to the Reports page showing daily report summaries with loading, empty, and detailed states, expandable content, and TL;DR bullets.
* **Improvements**
  * Standardized date-range formatting for clearer report timelines.
  * Improved reliability of duplicate report handling to reduce redundant entries.
* **Quality**
  * Report content is sanitized before display for safer rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->