### PR TITLE
feat: harden Sentry PII + PostHog /ingest proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,11 @@ SENTRY_PROJECT=gitpulse
 
 # PostHog Analytics
 NEXT_PUBLIC_POSTHOG_KEY=your_posthog_project_key
-NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+# Leave NEXT_PUBLIC_POSTHOG_HOST unset in production to route through /ingest proxy.
+# Set it only if you intentionally bypass the proxy.
+# NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+# Optional explicit PostHog app UI host (for toolbar/deep links); defaults to inferred host.
+# NEXT_PUBLIC_POSTHOG_UI_HOST=https://us.posthog.com
 
 # Convex Deploy Keys (set in Vercel; preview uses preview:..., production uses prod:...)
 CONVEX_DEPLOY_KEY=your_convex_deploy_key

--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           perspective: ${{ matrix.perspective }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          api-key: ${{ secrets.MOONSHOT_API_KEY }}
+          api-key: ${{ secrets.OPENROUTER_API_KEY != '' && secrets.OPENROUTER_API_KEY || secrets.MOONSHOT_API_KEY }}
 
   verdict:
     name: "Council Verdict"

--- a/components/PostHogProvider.tsx
+++ b/components/PostHogProvider.tsx
@@ -6,12 +6,31 @@ import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { useUser } from "@clerk/nextjs";
 
+const DEFAULT_POSTHOG_UI_HOST = "https://us.posthog.com";
+
+function deriveUiHost(apiHost: string | undefined): string | undefined {
+  if (!apiHost || apiHost.startsWith("/")) {
+    return undefined;
+  }
+
+  try {
+    return new URL(apiHost).origin;
+  } catch {
+    return undefined;
+  }
+}
+
 export function PostHogProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+      const apiHost = process.env.NEXT_PUBLIC_POSTHOG_HOST || "/ingest";
+
       posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "/ingest",
-        ui_host: "https://us.posthog.com",
+        api_host: apiHost,
+        ui_host:
+          process.env.NEXT_PUBLIC_POSTHOG_UI_HOST ||
+          deriveUiHost(process.env.NEXT_PUBLIC_POSTHOG_HOST) ||
+          DEFAULT_POSTHOG_UI_HOST,
         person_profiles: "identified_only",
         capture_pageview: false, // We'll capture manually for SPA
         capture_pageleave: true,

--- a/components/PostHogProvider.tsx
+++ b/components/PostHogProvider.tsx
@@ -10,11 +10,12 @@ export function PostHogProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
       posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-        api_host:
-          process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com",
+        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "/ingest",
+        ui_host: "https://us.posthog.com",
         person_profiles: "identified_only",
         capture_pageview: false, // We'll capture manually for SPA
         capture_pageleave: true,
+        respect_dnt: true,
       });
     }
   }, []);

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -58,5 +58,7 @@ module.exports = {
       statements: 60,
     },
   },
+  // Use V8 coverage instrumentation to avoid Babel-plugin dependency issues.
+  coverageProvider: "v8",
   coverageReporters: ["text", "lcov", "html", "json-summary"],
 };

--- a/lib/auth/publicRoutes.ts
+++ b/lib/auth/publicRoutes.ts
@@ -4,6 +4,7 @@ import { createRouteMatcher } from "@clerk/nextjs/server";
 export const PUBLIC_ROUTES = [
   "/",
   "/pricing(.*)",
+  "/ingest(.*)",
   "/sign-in(.*)",
   "/sign-up(.*)",
   "/api/webhooks(.*)",

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,12 +11,12 @@ const nextConfig: NextConfig = {
         destination: "https://us-assets.i.posthog.com/static/:path*",
       },
       {
-        source: "/ingest/:path*",
-        destination: "https://us.i.posthog.com/:path*",
-      },
-      {
         source: "/ingest/decide",
         destination: "https://us.i.posthog.com/decide",
+      },
+      {
+        source: "/ingest/:path*",
+        destination: "https://us.i.posthog.com/:path*",
       },
     ];
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,22 @@ import { withSentryConfig } from "@sentry/nextjs";
 const nextConfig: NextConfig = {
   // Exclude pino from bundling - it uses worker threads that Turbopack can't handle
   serverExternalPackages: ["pino", "pino-pretty", "thread-stream"],
+  async rewrites() {
+    return [
+      {
+        source: "/ingest/static/:path*",
+        destination: "https://us-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/ingest/:path*",
+        destination: "https://us.i.posthog.com/:path*",
+      },
+      {
+        source: "/ingest/decide",
+        destination: "https://us.i.posthog.com/decide",
+      },
+    ];
+  },
 };
 
 export default withSentryConfig(nextConfig, {

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -4,6 +4,7 @@ import { scrubPii, getSentryEnvironment } from "@/lib/sentry";
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.1,
+  sendDefaultPii: false,
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ["localhost", /^https:\/\/[^/]*\.convex\.cloud/],
   replaysSessionSampleRate: 0,

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -4,6 +4,7 @@ import { scrubPii, getSentryEnvironment } from "@/lib/sentry";
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.1,
+  sendDefaultPii: false,
   debug: false,
   environment: getSentryEnvironment(),
   beforeSend: scrubPii,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,6 +4,7 @@ import { scrubPii, getSentryEnvironment } from "@/lib/sentry";
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.1,
+  sendDefaultPii: false,
   debug: false,
   environment: getSentryEnvironment(),
   integrations: [Sentry.httpIntegration()],


### PR DESCRIPTION
## Summary
Harden observability configuration: Sentry PII protection and PostHog ad-blocker bypass.

## Changes
- Sentry: add `sendDefaultPii: false` to all 3 configs (client, server, edge)
- PostHog: add `respect_dnt: true`, `ui_host`
- PostHog: switch default host from direct to `/ingest` proxy
- Next.js: add `/ingest` proxy rewrites
- Auth: add `/ingest(.*)` to Clerk public routes

## Test plan
- [ ] Verify PostHog events fire via `/ingest` proxy
- [ ] Verify Sentry events don't contain PII (check breadcrumbs)
- [ ] Verify `/ingest` traffic isn't blocked by Clerk middleware

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit user-identification control to manage identification lifecycle.

* **Analytics & Security Updates**
  * Analytics now respects Do-Not-Track browser settings.
  * Analytics traffic can be routed through a local ingest endpoint/proxy; UI host falls back to a derived default if not configured.
  * Error reporting updated to avoid sending personal data by default.

* **Chores**
  * Configuration examples and guidance for analytics UI/host settings updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->