### PR TITLE
ci: add merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,19 @@ jobs:
 
       - name: Run ${{ matrix.check }}
         run: bun run ${{ matrix.check }}
+
+  merge-gate:
+    name: merge-gate
+    needs: [trufflehog, security-audit, quality-gates]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: |
+          if [[ "${{ needs.trufflehog.result }}" == "success" && \
+                "${{ needs.security-audit.result }}" == "success" && \
+                "${{ needs.quality-gates.result }}" == "success" ]]; then
+            echo "merge-gate green"
+          else
+            echo "merge-gate red (trufflehog=${{ needs.trufflehog.result }}, security-audit=${{ needs.security-audit.result }}, quality-gates=${{ needs.quality-gates.result }})"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
     name: merge-gate
     needs: [trufflehog, security-audit, quality-gates]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always()
     steps:
       - name: Check required CI results
@@ -76,6 +77,8 @@ jobs:
         run: |
           echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value.result)"'
 
+          # These dependencies are intentionally unconditional. A skipped result
+          # indicates broken CI topology, not a successful required check.
           if echo "$NEEDS_JSON" | jq -e 'all(.[]; .result == "success")' >/dev/null; then
             echo "merge-gate green"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,15 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - run: |
-          if [[ "${{ needs.trufflehog.result }}" == "success" && \
-                "${{ needs.security-audit.result }}" == "success" && \
-                "${{ needs.quality-gates.result }}" == "success" ]]; then
+      - name: Check required CI results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value.result)"'
+
+          if echo "$NEEDS_JSON" | jq -e 'all(.[]; .result == "success")' >/dev/null; then
             echo "merge-gate green"
           else
-            echo "merge-gate red (trufflehog=${{ needs.trufflehog.result }}, security-audit=${{ needs.security-audit.result }}, quality-gates=${{ needs.quality-gates.result }})"
+            echo "merge-gate red"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- add a stable `merge-gate` job that aggregates the repo's deterministic CI jobs
- prepare the repo for a single required status check instead of bespoke or multi-check protection
- reduce merge friction without dropping real quality gates

## Why
Org policy is moving toward one required deterministic merge gate per repo. This change keeps the real CI jobs intact, but adds one explicit gate name that branch protection can require without depending on AI review checks or multiple separate required checks.


## PR Fix Pass
Before:
- The branch conflicted with `master` because the original `merge-gate` change targeted the old pnpm/deployment-era CI layout.
- The old implementation omitted `trufflehog`, so a secrets-scan failure could bypass a single required `merge-gate`.
- The gate duplicated job names in both `needs` and shell conditionals, increasing change amplification.

After:
- Rebased the PR onto the current Bun CI workflow shape.
- `merge-gate` now fans in from `trufflehog`, `security-audit`, and `quality-gates`.
- The gate keeps `if: always()` for single-check safety, but reads `${{ toJSON(needs) }}` so `needs` is the only source of truth.
- Replied to and resolved all open inline review threads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced a CI merge-gate that runs after other checks, aggregates and prints per-check results, and enforces that all required checks report success before allowing progress. The gate always executes, has a short timeout, and returns a non-zero exit when any required check fails to ensure collective validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->