### PR TITLE
fix: correct pr review window coverage

### DIFF
--- a/.groom/retro.md
+++ b/.groom/retro.md
@@ -1,0 +1,21 @@
+# Retro Log
+
+Append one entry per delivered issue.
+
+## Format
+
+```text
+## YYYY-MM-DD Issue #N
+- Predicted: effort/<size>
+- Actual: <size>
+- Scope: <what changed>
+- Blockers: <none|details>
+- Pattern: <reusable lesson>
+```
+
+## 2026-03-07 Issue #162
+- Predicted: effort/s
+- Actual: effort/s
+- Scope: Replaced truncated PR candidate pagination with window-correct GitHub search for opened, merged, and review coverage.
+- Blockers: retro log file missing
+- Pattern: Workflow-owned repo artifacts should be initialized by the workflow, not assumed.

--- a/packages/agent-core/src/github/activity.test.ts
+++ b/packages/agent-core/src/github/activity.test.ts
@@ -15,10 +15,18 @@ describe("fetchActivityWindow", () => {
   beforeEach(() => {
     globalThis.fetch = (async (input) => {
       const url = String(input);
-      if (url.includes("/commits?") || url.includes("/pulls?")) {
+      if (url.includes("/commits?")) {
         return new Response("[]", {
           status: 200,
           headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (url.includes("/search/issues?")) {
+        return jsonResponse({
+          total_count: 0,
+          incomplete_results: false,
+          items: [],
         });
       }
 
@@ -51,23 +59,31 @@ describe("fetchActivityWindow", () => {
         });
       }
 
-      if (url.includes("/pulls?")) {
-        return new Response(
-          JSON.stringify([
+      if (url.includes("/search/issues?") && (url.includes("merged%3A") || url.includes("updated%3A"))) {
+        return jsonResponse({
+          total_count: 0,
+          incomplete_results: false,
+          items: [],
+        });
+      }
+
+      if (url.includes("/search/issues?") && url.includes("created%3A")) {
+        return jsonResponse({
+          total_count: 1,
+          incomplete_results: false,
+          items: [
             {
               number: 42,
               title: "deleted author PR",
               html_url: "https://github.com/misty-step/gitpulse/pull/42",
               created_at: "2026-03-02T10:00:00.000Z",
-              merged_at: null,
+              closed_at: null,
+              updated_at: "2026-03-02T10:00:00.000Z",
               user: null,
+              pull_request: {},
             },
-          ]),
-          {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          },
-        );
+          ],
+        });
       }
 
       throw new Error(`Unexpected fetch: ${url}`);
@@ -89,4 +105,156 @@ describe("fetchActivityWindow", () => {
       },
     ]);
   });
+
+  test("collects PR opened and merged events from window-correct search results", async () => {
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      if (url.includes("/commits?")) {
+        return jsonResponse([]);
+      }
+
+      if (url.includes("/search/issues?") && url.includes("created%3A")) {
+        return jsonResponse({
+          total_count: 1,
+          incomplete_results: false,
+          items: [
+            {
+              number: 77,
+              title: "search-opened pr",
+              html_url: "https://github.com/misty-step/gitpulse/pull/77",
+              created_at: "2026-03-03T09:00:00.000Z",
+              closed_at: null,
+              updated_at: "2026-03-06T09:00:00.000Z",
+              user: { login: "phaedrus" },
+              pull_request: {},
+            },
+          ],
+        });
+      }
+
+      if (url.includes("/search/issues?") && url.includes("merged%3A")) {
+        return jsonResponse({
+          total_count: 1,
+          incomplete_results: false,
+          items: [
+            {
+              number: 78,
+              title: "search-merged pr",
+              html_url: "https://github.com/misty-step/gitpulse/pull/78",
+              created_at: "2026-02-25T09:00:00.000Z",
+              closed_at: "2026-03-04T12:30:00.000Z",
+              updated_at: "2026-03-04T12:30:00.000Z",
+              user: { login: "phaedrus" },
+              pull_request: {},
+            },
+          ],
+        });
+      }
+
+      if (url.includes("/search/issues?") && url.includes("updated%3A")) {
+        return jsonResponse({
+          total_count: 0,
+          incomplete_results: false,
+          items: [],
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const result = await fetchActivityWindow({
+      window: WINDOW,
+      scope: { repos: ["misty-step/gitpulse"] },
+    });
+
+    expect(result.events).toEqual([
+      {
+        type: "pull_request_merged",
+        repo: "misty-step/gitpulse",
+        actor: "phaedrus",
+        title: "search-merged pr",
+        url: "https://github.com/misty-step/gitpulse/pull/78",
+        timestamp: "2026-03-04T12:30:00.000Z",
+      },
+      {
+        type: "pull_request_opened",
+        repo: "misty-step/gitpulse",
+        actor: "phaedrus",
+        title: "search-opened pr",
+        url: "https://github.com/misty-step/gitpulse/pull/77",
+        timestamp: "2026-03-03T09:00:00.000Z",
+      },
+    ]);
+  });
+
+  test("collects reviews from PRs updated in-window even when the PR was opened outside the window", async () => {
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      if (url.includes("/commits?")) {
+        return jsonResponse([]);
+      }
+
+      if (url.includes("/search/issues?") && (url.includes("created%3A") || url.includes("merged%3A"))) {
+        return jsonResponse({
+          total_count: 0,
+          incomplete_results: false,
+          items: [],
+        });
+      }
+
+      if (url.includes("/search/issues?") && url.includes("updated%3A")) {
+        return jsonResponse({
+          total_count: 1,
+          incomplete_results: false,
+          items: [
+            {
+              number: 91,
+              title: "stale PR with fresh review",
+              html_url: "https://github.com/misty-step/gitpulse/pull/91",
+              created_at: "2026-02-20T09:00:00.000Z",
+              closed_at: null,
+              updated_at: "2026-03-04T08:00:00.000Z",
+              user: { login: "author" },
+              pull_request: {},
+            },
+          ],
+        });
+      }
+
+      if (url.includes("/pulls/91/reviews?")) {
+        return jsonResponse([
+          {
+            html_url: "https://github.com/misty-step/gitpulse/pull/91#pullrequestreview-1",
+            submitted_at: "2026-03-04T08:00:00.000Z",
+            user: { login: "reviewer" },
+          },
+        ]);
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const result = await fetchActivityWindow({
+      window: WINDOW,
+      scope: { repos: ["misty-step/gitpulse"], contributors: ["reviewer"] },
+    });
+
+    expect(result.events).toEqual([
+      {
+        type: "pull_request_reviewed",
+        repo: "misty-step/gitpulse",
+        actor: "reviewer",
+        title: "Review on #91: stale PR with fresh review",
+        url: "https://github.com/misty-step/gitpulse/pull/91#pullrequestreview-1",
+        timestamp: "2026-03-04T08:00:00.000Z",
+      },
+    ]);
+  });
 });
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/packages/agent-core/src/github/activity.test.ts
+++ b/packages/agent-core/src/github/activity.test.ts
@@ -250,6 +250,164 @@ describe("fetchActivityWindow", () => {
       },
     ]);
   });
+
+  test("fetches additional search pages when a window spans more than one page", async () => {
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      const page = new URL(url).searchParams.get("page");
+      if (url.includes("/commits?")) {
+        return jsonResponse([]);
+      }
+
+      if (url.includes("/search/issues?") && url.includes("merged%3A")) {
+        return jsonResponse({ total_count: 0, incomplete_results: false, items: [] });
+      }
+
+      if (url.includes("/search/issues?") && url.includes("updated%3A")) {
+        return jsonResponse({ total_count: 0, incomplete_results: false, items: [] });
+      }
+
+      if (url.includes("/search/issues?") && url.includes("created%3A") && page === "1") {
+        return jsonResponse({
+          total_count: 101,
+          incomplete_results: false,
+          items: Array.from({ length: 100 }, (_, index) => ({
+            number: index + 1,
+            title: `page-one-${index + 1}`,
+            html_url: `https://github.com/misty-step/gitpulse/pull/${index + 1}`,
+            created_at: "2026-03-02T10:00:00.000Z",
+            closed_at: null,
+            user: { login: "phaedrus" },
+            pull_request: {},
+          })),
+        });
+      }
+
+      if (url.includes("/search/issues?") && url.includes("created%3A") && page === "2") {
+        return jsonResponse({
+          total_count: 101,
+          incomplete_results: false,
+          items: [
+            {
+              number: 101,
+              title: "page-two-101",
+              html_url: "https://github.com/misty-step/gitpulse/pull/101",
+              created_at: "2026-03-02T10:00:00.000Z",
+              closed_at: null,
+              user: { login: "phaedrus" },
+              pull_request: {},
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const result = await fetchActivityWindow({
+      window: WINDOW,
+      scope: { repos: ["misty-step/gitpulse"] },
+    });
+
+    expect(result.events.filter((event) => event.type === "pull_request_opened")).toHaveLength(101);
+  });
+
+  test("splits oversized search windows, dedupes duplicates, and warns only on leaf incomplete results", async () => {
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      const decodedUrl = decodeURIComponent(url);
+
+      if (decodedUrl.includes("/commits?")) {
+        return jsonResponse([]);
+      }
+
+      if (decodedUrl.includes("/search/issues?") && (decodedUrl.includes("merged:") || decodedUrl.includes("updated:"))) {
+        return jsonResponse({ total_count: 0, incomplete_results: false, items: [] });
+      }
+
+      if (
+        decodedUrl.includes("/search/issues?") &&
+        decodedUrl.includes("created:2026-03-01T00:00:00.000Z..2026-03-05T00:00:00.000Z")
+      ) {
+        return jsonResponse({
+          total_count: 1001,
+          incomplete_results: true,
+          items: [
+            {
+              number: 7,
+              title: "discarded-root-page",
+              html_url: "https://github.com/misty-step/gitpulse/pull/7",
+              created_at: "2026-03-02T00:00:00.000Z",
+              closed_at: null,
+              user: { login: "phaedrus" },
+              pull_request: {},
+            },
+          ],
+        });
+      }
+
+      if (
+        decodedUrl.includes("/search/issues?") &&
+        decodedUrl.includes("created:2026-03-01T00:00:00.000Z..2026-03-03T00:00:00.000Z")
+      ) {
+        return jsonResponse({
+          total_count: 2,
+          incomplete_results: true,
+          items: [
+            {
+              number: 88,
+              title: "left-split",
+              html_url: "https://github.com/misty-step/gitpulse/pull/88",
+              created_at: "2026-03-02T08:00:00.000Z",
+              closed_at: null,
+              user: { login: "phaedrus" },
+              pull_request: {},
+            },
+          ],
+        });
+      }
+
+      if (
+        decodedUrl.includes("/search/issues?") &&
+        decodedUrl.includes("created:2026-03-03T00:00:00.001Z..2026-03-05T00:00:00.000Z")
+      ) {
+        return jsonResponse({
+          total_count: 2,
+          incomplete_results: false,
+          items: [
+            {
+              number: 88,
+              title: "right-duplicate",
+              html_url: "https://github.com/misty-step/gitpulse/pull/88",
+              created_at: "2026-03-02T08:00:00.000Z",
+              closed_at: null,
+              user: { login: "phaedrus" },
+              pull_request: {},
+            },
+            {
+              number: 89,
+              title: "right-unique",
+              html_url: "https://github.com/misty-step/gitpulse/pull/89",
+              created_at: "2026-03-04T08:00:00.000Z",
+              closed_at: null,
+              user: { login: "phaedrus" },
+              pull_request: {},
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const result = await fetchActivityWindow({
+      window: WINDOW,
+      scope: { repos: ["misty-step/gitpulse"] },
+    });
+
+    expect(result.events.filter((event) => event.type === "pull_request_opened")).toHaveLength(2);
+    expect(result.warnings).toEqual(["GitHub search returned incomplete PR results for misty-step/gitpulse (created)."]);
+  });
 });
 
 function jsonResponse(body: unknown): Response {

--- a/packages/agent-core/src/github/activity.test.ts
+++ b/packages/agent-core/src/github/activity.test.ts
@@ -251,6 +251,97 @@ describe("fetchActivityWindow", () => {
     ]);
   });
 
+  test("collects review events across multiple review pages for the same pull request", async () => {
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      const page = new URL(url).searchParams.get("page");
+      if (url.includes("/commits?")) {
+        return jsonResponse([]);
+      }
+
+      if (url.includes("/search/issues?") && (url.includes("created%3A") || url.includes("merged%3A"))) {
+        return jsonResponse({
+          total_count: 0,
+          incomplete_results: false,
+          items: [],
+        });
+      }
+
+      if (url.includes("/search/issues?") && url.includes("updated%3A")) {
+        return jsonResponse({
+          total_count: 1,
+          incomplete_results: false,
+          items: [
+            {
+              number: 93,
+              title: "multipage reviews",
+              html_url: "https://github.com/misty-step/gitpulse/pull/93",
+              created_at: "2026-02-28T09:00:00.000Z",
+              closed_at: null,
+              user: { login: "author" },
+              pull_request: {},
+            },
+          ],
+        });
+      }
+
+      if (url.includes("/pulls/93/reviews?per_page=100") && page === null) {
+        return new Response(
+          JSON.stringify([
+            {
+              html_url: "https://github.com/misty-step/gitpulse/pull/93#pullrequestreview-100",
+              submitted_at: "2026-03-03T08:00:00.000Z",
+              user: { login: "reviewer-100" },
+            },
+          ]),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              link: '<https://api.github.com/repos/misty-step/gitpulse/pulls/93/reviews?per_page=100&page=2>; rel="next"',
+            },
+          },
+        );
+      }
+
+      if (url.includes("/pulls/93/reviews?per_page=100&page=2") && page === "2") {
+        return jsonResponse([
+          {
+            html_url: "https://github.com/misty-step/gitpulse/pull/93#pullrequestreview-101",
+            submitted_at: "2026-03-03T09:00:00.000Z",
+            user: { login: "reviewer-101" },
+          },
+        ]);
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const result = await fetchActivityWindow({
+      window: WINDOW,
+      scope: { repos: ["misty-step/gitpulse"] },
+    });
+
+    expect(result.events.filter((event) => event.type === "pull_request_reviewed")).toEqual([
+      {
+        type: "pull_request_reviewed",
+        repo: "misty-step/gitpulse",
+        actor: "reviewer-101",
+        title: "Review on #93: multipage reviews",
+        url: "https://github.com/misty-step/gitpulse/pull/93#pullrequestreview-101",
+        timestamp: "2026-03-03T09:00:00.000Z",
+      },
+      {
+        type: "pull_request_reviewed",
+        repo: "misty-step/gitpulse",
+        actor: "reviewer-100",
+        title: "Review on #93: multipage reviews",
+        url: "https://github.com/misty-step/gitpulse/pull/93#pullrequestreview-100",
+        timestamp: "2026-03-03T08:00:00.000Z",
+      },
+    ]);
+  });
+
   test("fetches additional search pages when a window spans more than one page", async () => {
     globalThis.fetch = (async (input) => {
       const url = String(input);

--- a/packages/agent-core/src/github/activity.test.ts
+++ b/packages/agent-core/src/github/activity.test.ts
@@ -187,6 +187,82 @@ describe("fetchActivityWindow", () => {
     ]);
   });
 
+  test("post-filters second-precision search results back to the exact window", async () => {
+    const narrowWindow: TimeWindow = {
+      from: "2026-03-03T09:00:00.500Z",
+      to: "2026-03-03T09:00:00.900Z",
+    };
+
+    globalThis.fetch = (async (input) => {
+      const url = decodeURIComponent(String(input));
+      if (url.includes("/commits?")) {
+        return jsonResponse([]);
+      }
+
+      if (url.includes("/search/issues?") && url.includes("created:2026-03-03T09:00:00Z..2026-03-03T09:00:01Z")) {
+        return jsonResponse({
+          total_count: 3,
+          incomplete_results: false,
+          items: [
+            {
+              number: 70,
+              title: "too-early",
+              html_url: "https://github.com/misty-step/gitpulse/pull/70",
+              created_at: "2026-03-03T09:00:00.250Z",
+              closed_at: null,
+              user: { login: "phaedrus" },
+              pull_request: {},
+            },
+            {
+              number: 71,
+              title: "in-window",
+              html_url: "https://github.com/misty-step/gitpulse/pull/71",
+              created_at: "2026-03-03T09:00:00.750Z",
+              closed_at: null,
+              user: { login: "phaedrus" },
+              pull_request: {},
+            },
+            {
+              number: 72,
+              title: "too-late",
+              html_url: "https://github.com/misty-step/gitpulse/pull/72",
+              created_at: "2026-03-03T09:00:01.000Z",
+              closed_at: null,
+              user: { login: "phaedrus" },
+              pull_request: {},
+            },
+          ],
+        });
+      }
+
+      if (url.includes("/search/issues?") && (url.includes("merged:") || url.includes("updated:"))) {
+        return jsonResponse({
+          total_count: 0,
+          incomplete_results: false,
+          items: [],
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const result = await fetchActivityWindow({
+      window: narrowWindow,
+      scope: { repos: ["misty-step/gitpulse"] },
+    });
+
+    expect(result.events).toEqual([
+      {
+        type: "pull_request_opened",
+        repo: "misty-step/gitpulse",
+        actor: "phaedrus",
+        title: "in-window",
+        url: "https://github.com/misty-step/gitpulse/pull/71",
+        timestamp: "2026-03-03T09:00:00.750Z",
+      },
+    ]);
+  });
+
   test("collects reviews from PRs updated in-window even when the PR was opened outside the window", async () => {
     globalThis.fetch = (async (input) => {
       const url = String(input);
@@ -403,6 +479,66 @@ describe("fetchActivityWindow", () => {
     expect(result.events.filter((event) => event.type === "pull_request_opened")).toHaveLength(101);
   });
 
+  test("warns when later search pages report incomplete results", async () => {
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      const page = new URL(url).searchParams.get("page");
+      if (url.includes("/commits?")) {
+        return jsonResponse([]);
+      }
+
+      if (url.includes("/search/issues?") && (url.includes("merged%3A") || url.includes("updated%3A"))) {
+        return jsonResponse({ total_count: 0, incomplete_results: false, items: [] });
+      }
+
+      if (url.includes("/search/issues?") && url.includes("created%3A") && page === "1") {
+        return jsonResponse({
+          total_count: 101,
+          incomplete_results: false,
+          items: [
+            {
+              number: 120,
+              title: "page-one",
+              html_url: "https://github.com/misty-step/gitpulse/pull/120",
+              created_at: "2026-03-02T10:00:00.000Z",
+              closed_at: null,
+              user: { login: "phaedrus" },
+              pull_request: {},
+            },
+          ],
+        });
+      }
+
+      if (url.includes("/search/issues?") && url.includes("created%3A") && page === "2") {
+        return jsonResponse({
+          total_count: 101,
+          incomplete_results: true,
+          items: [
+            {
+              number: 121,
+              title: "page-two",
+              html_url: "https://github.com/misty-step/gitpulse/pull/121",
+              created_at: "2026-03-02T11:00:00.000Z",
+              closed_at: null,
+              user: { login: "phaedrus" },
+              pull_request: {},
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const result = await fetchActivityWindow({
+      window: WINDOW,
+      scope: { repos: ["misty-step/gitpulse"] },
+    });
+
+    expect(result.events.filter((event) => event.type === "pull_request_opened")).toHaveLength(2);
+    expect(result.warnings).toEqual(["GitHub search returned incomplete PR results for misty-step/gitpulse (created)."]);
+  });
+
   test("splits oversized search windows, dedupes duplicates, and warns only on leaf incomplete results", async () => {
     globalThis.fetch = (async (input) => {
       const url = String(input);
@@ -418,7 +554,7 @@ describe("fetchActivityWindow", () => {
 
       if (
         decodedUrl.includes("/search/issues?") &&
-        decodedUrl.includes("created:2026-03-01T00:00:00.000Z..2026-03-05T00:00:00.000Z")
+        decodedUrl.includes("created:2026-03-01T00:00:00Z..2026-03-05T00:00:00Z")
       ) {
         return jsonResponse({
           total_count: 1001,
@@ -439,7 +575,7 @@ describe("fetchActivityWindow", () => {
 
       if (
         decodedUrl.includes("/search/issues?") &&
-        decodedUrl.includes("created:2026-03-01T00:00:00.000Z..2026-03-03T00:00:00.000Z")
+        decodedUrl.includes("created:2026-03-01T00:00:00Z..2026-03-03T00:00:00Z")
       ) {
         return jsonResponse({
           total_count: 2,
@@ -460,7 +596,7 @@ describe("fetchActivityWindow", () => {
 
       if (
         decodedUrl.includes("/search/issues?") &&
-        decodedUrl.includes("created:2026-03-03T00:00:00.001Z..2026-03-05T00:00:00.000Z")
+        decodedUrl.includes("created:2026-03-03T00:00:01Z..2026-03-05T00:00:00Z")
       ) {
         return jsonResponse({
           total_count: 2,
@@ -498,6 +634,53 @@ describe("fetchActivityWindow", () => {
 
     expect(result.events.filter((event) => event.type === "pull_request_opened")).toHaveLength(2);
     expect(result.warnings).toEqual(["GitHub search returned incomplete PR results for misty-step/gitpulse (created)."]);
+  });
+
+  test("warns when merged search results omit closed_at", async () => {
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      if (url.includes("/commits?")) {
+        return jsonResponse([]);
+      }
+
+      if (url.includes("/search/issues?") && url.includes("created%3A")) {
+        return jsonResponse({ total_count: 0, incomplete_results: false, items: [] });
+      }
+
+      if (url.includes("/search/issues?") && url.includes("merged%3A")) {
+        return jsonResponse({
+          total_count: 1,
+          incomplete_results: false,
+          items: [
+            {
+              number: 140,
+              title: "missing closed_at",
+              html_url: "https://github.com/misty-step/gitpulse/pull/140",
+              created_at: "2026-02-25T09:00:00.000Z",
+              closed_at: null,
+              user: { login: "phaedrus" },
+              pull_request: {},
+            },
+          ],
+        });
+      }
+
+      if (url.includes("/search/issues?") && url.includes("updated%3A")) {
+        return jsonResponse({ total_count: 0, incomplete_results: false, items: [] });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const result = await fetchActivityWindow({
+      window: WINDOW,
+      scope: { repos: ["misty-step/gitpulse"] },
+    });
+
+    expect(result.events).toEqual([]);
+    expect(result.warnings).toEqual([
+      "GitHub search returned merged PR without closed_at for misty-step/gitpulse#140; skipping.",
+    ]);
   });
 });
 

--- a/packages/agent-core/src/github/activity.ts
+++ b/packages/agent-core/src/github/activity.ts
@@ -17,12 +17,18 @@ type GitHubCommit = {
   };
 };
 
-type GitHubPullRequest = {
+type GitHubSearchResult<T> = {
+  total_count: number;
+  incomplete_results: boolean;
+  items: T[];
+};
+
+type GitHubSearchPullRequest = {
   number: number;
   title: string;
   html_url: string;
   created_at: string;
-  merged_at: string | null;
+  closed_at: string | null;
   user: { login: string } | null;
 };
 
@@ -179,47 +185,43 @@ async function fetchRepoEvents(
     });
   }
 
-  const pulls = await client.getPagedJson<GitHubPullRequest>(
-    `${repoPath}/pulls?state=all&sort=updated&direction=desc&per_page=100`,
-    { maxPages: 2 },
-  );
-
-  const candidatePulls = pulls.filter((pull) => {
+  const openedPulls = await searchPullRequests(client, repo, window, "created", warnings);
+  for (const pull of openedPulls) {
     const actor = pull.user?.login ?? "ghost";
     if (!includeContributor(actor, contributorFilter)) {
-      return false;
+      continue;
     }
 
-    return inWindow(pull.created_at, window) || (pull.merged_at ? inWindow(pull.merged_at, window) : false);
-  });
-
-  for (const pull of candidatePulls) {
-    const actor = pull.user?.login ?? "ghost";
-
-    if (inWindow(pull.created_at, window)) {
-      events.push({
-        type: "pull_request_opened",
-        repo,
-        actor,
-        title: pull.title,
-        url: pull.html_url,
-        timestamp: toIso(pull.created_at),
-      });
-    }
-
-    if (pull.merged_at && inWindow(pull.merged_at, window)) {
-      events.push({
-        type: "pull_request_merged",
-        repo,
-        actor,
-        title: pull.title,
-        url: pull.html_url,
-        timestamp: toIso(pull.merged_at),
-      });
-    }
+    events.push({
+      type: "pull_request_opened",
+      repo,
+      actor,
+      title: pull.title,
+      url: pull.html_url,
+      timestamp: toIso(pull.created_at),
+    });
   }
 
-  for (const pull of candidatePulls) {
+  const mergedPulls = await searchPullRequests(client, repo, window, "merged", warnings);
+  for (const pull of mergedPulls) {
+    const actor = pull.user?.login ?? "ghost";
+    const mergedAt = pull.closed_at;
+    if (!mergedAt || !includeContributor(actor, contributorFilter)) {
+      continue;
+    }
+
+    events.push({
+      type: "pull_request_merged",
+      repo,
+      actor,
+      title: pull.title,
+      url: pull.html_url,
+      timestamp: toIso(mergedAt),
+    });
+  }
+
+  const reviewPulls = await searchPullRequests(client, repo, window, "updated", warnings);
+  for (const pull of reviewPulls) {
     try {
       const reviews = await client.getPagedJson<GitHubReview>(
         `${repoPath}/pulls/${pull.number}/reviews?per_page=100`,
@@ -250,6 +252,92 @@ async function fetchRepoEvents(
   }
 
   return events;
+}
+
+async function searchPullRequests(
+  client: GitHubClient,
+  repo: string,
+  window: TimeWindow,
+  field: "created" | "merged" | "updated",
+  warnings: string[],
+): Promise<GitHubSearchPullRequest[]> {
+  const deduped = new Map<number, GitHubSearchPullRequest>();
+  const pulls = await searchPullRequestsRange(
+    client,
+    repo,
+    field,
+    Date.parse(window.from),
+    Date.parse(window.to),
+    warnings,
+  );
+
+  for (const pull of pulls) {
+    deduped.set(pull.number, pull);
+  }
+
+  return [...deduped.values()];
+}
+
+async function searchPullRequestsRange(
+  client: GitHubClient,
+  repo: string,
+  field: "created" | "merged" | "updated",
+  fromMs: number,
+  toMs: number,
+  warnings: string[],
+): Promise<GitHubSearchPullRequest[]> {
+  const query = buildPullRequestSearchQuery(repo, field, fromMs, toMs);
+  const firstPage = await client.getJson<GitHubSearchResult<GitHubSearchPullRequest>>(searchIssuesPath(query, 1));
+
+  if (firstPage.incomplete_results) {
+    warnings.push(`GitHub search returned incomplete PR results for ${repo} (${field}).`);
+  }
+
+  if (firstPage.total_count > 1000) {
+    if (fromMs >= toMs) {
+      warnings.push(`GitHub search exceeded 1000 PRs for ${repo} (${field}) within a 1ms slice; results truncated.`);
+      return firstPage.items;
+    }
+
+    const midpoint = Math.floor((fromMs + toMs) / 2);
+    const [left, right] = await Promise.all([
+      searchPullRequestsRange(client, repo, field, fromMs, midpoint, warnings),
+      searchPullRequestsRange(client, repo, field, midpoint + 1, toMs, warnings),
+    ]);
+    return [...left, ...right];
+  }
+
+  const pulls = [...firstPage.items];
+  const totalPages = Math.min(10, Math.ceil(firstPage.total_count / 100));
+  for (let page = 2; page <= totalPages; page += 1) {
+    const response = await client.getJson<GitHubSearchResult<GitHubSearchPullRequest>>(searchIssuesPath(query, page));
+    pulls.push(...response.items);
+  }
+
+  return pulls;
+}
+
+function buildPullRequestSearchQuery(
+  repo: string,
+  field: "created" | "merged" | "updated",
+  fromMs: number,
+  toMs: number,
+): string {
+  const parts = [`repo:${repo}`, "is:pr"];
+  if (field === "merged") {
+    parts.push("is:merged");
+  }
+  parts.push(`${field}:${new Date(fromMs).toISOString()}..${new Date(toMs).toISOString()}`);
+  return parts.join(" ");
+}
+
+function searchIssuesPath(query: string, page: number): string {
+  const params = new URLSearchParams({
+    q: query,
+    per_page: "100",
+    page: String(page),
+  });
+  return `/search/issues?${params.toString()}`;
 }
 
 function includeContributor(actor: string, filter: Set<string>): boolean {

--- a/packages/agent-core/src/github/activity.ts
+++ b/packages/agent-core/src/github/activity.ts
@@ -29,6 +29,7 @@ type GitHubSearchPullRequest = {
   html_url: string;
   created_at: string;
   closed_at: string | null;
+  pull_request?: Record<string, unknown>;
   user: { login: string } | null;
 };
 
@@ -52,6 +53,9 @@ export type FetchActivityInput = {
   githubToken?: string;
   maxRepos?: number;
 };
+
+const SEARCH_PAGE_SIZE = 100;
+const SEARCH_RESULT_LIMIT = 1000;
 
 export async function fetchActivityWindow(input: FetchActivityInput): Promise<ActivityWindowData> {
   const scope = normalizeScope(input.scope);
@@ -205,6 +209,7 @@ async function fetchRepoEvents(
   const mergedPulls = await searchPullRequests(client, repo, window, "merged", warnings);
   for (const pull of mergedPulls) {
     const actor = pull.user?.login ?? "ghost";
+    // GitHub Search exposes merged PR timestamps as closed_at for is:merged queries.
     const mergedAt = pull.closed_at;
     if (!mergedAt || !includeContributor(actor, contributorFilter)) {
       continue;
@@ -261,7 +266,6 @@ async function searchPullRequests(
   field: "created" | "merged" | "updated",
   warnings: string[],
 ): Promise<GitHubSearchPullRequest[]> {
-  const deduped = new Map<number, GitHubSearchPullRequest>();
   const pulls = await searchPullRequestsRange(
     client,
     repo,
@@ -271,6 +275,7 @@ async function searchPullRequests(
     warnings,
   );
 
+  const deduped = new Map<number, GitHubSearchPullRequest>();
   for (const pull of pulls) {
     deduped.set(pull.number, pull);
   }
@@ -287,30 +292,31 @@ async function searchPullRequestsRange(
   warnings: string[],
 ): Promise<GitHubSearchPullRequest[]> {
   const query = buildPullRequestSearchQuery(repo, field, fromMs, toMs);
-  const firstPage = await client.getJson<GitHubSearchResult<GitHubSearchPullRequest>>(searchIssuesPath(query, 1));
+  const firstPage = await client.getJson<GitHubSearchResult<GitHubSearchPullRequest>>(searchIssuesPath(query, field, 1));
+
+  if (firstPage.total_count > SEARCH_RESULT_LIMIT) {
+    if (fromMs >= toMs) {
+      warnings.push(
+        `GitHub search exceeded ${SEARCH_RESULT_LIMIT} PRs for ${repo} (${field}) within a 1ms slice; only the first ${SEARCH_PAGE_SIZE} results were returned.`,
+      );
+      return firstPage.items;
+    }
+
+    const midpoint = Math.floor((fromMs + toMs) / 2);
+    // firstPage.items span the full range and cannot be assigned to a child slice without duplication.
+    const left = await searchPullRequestsRange(client, repo, field, fromMs, midpoint, warnings);
+    const right = await searchPullRequestsRange(client, repo, field, midpoint + 1, toMs, warnings);
+    return [...left, ...right];
+  }
 
   if (firstPage.incomplete_results) {
     warnings.push(`GitHub search returned incomplete PR results for ${repo} (${field}).`);
   }
 
-  if (firstPage.total_count > 1000) {
-    if (fromMs >= toMs) {
-      warnings.push(`GitHub search exceeded 1000 PRs for ${repo} (${field}) within a 1ms slice; results truncated.`);
-      return firstPage.items;
-    }
-
-    const midpoint = Math.floor((fromMs + toMs) / 2);
-    const [left, right] = await Promise.all([
-      searchPullRequestsRange(client, repo, field, fromMs, midpoint, warnings),
-      searchPullRequestsRange(client, repo, field, midpoint + 1, toMs, warnings),
-    ]);
-    return [...left, ...right];
-  }
-
   const pulls = [...firstPage.items];
-  const totalPages = Math.min(10, Math.ceil(firstPage.total_count / 100));
+  const totalPages = Math.min(SEARCH_RESULT_LIMIT / SEARCH_PAGE_SIZE, Math.ceil(firstPage.total_count / SEARCH_PAGE_SIZE));
   for (let page = 2; page <= totalPages; page += 1) {
-    const response = await client.getJson<GitHubSearchResult<GitHubSearchPullRequest>>(searchIssuesPath(query, page));
+    const response = await client.getJson<GitHubSearchResult<GitHubSearchPullRequest>>(searchIssuesPath(query, field, page));
     pulls.push(...response.items);
   }
 
@@ -331,13 +337,19 @@ function buildPullRequestSearchQuery(
   return parts.join(" ");
 }
 
-function searchIssuesPath(query: string, page: number): string {
+function searchIssuesPath(query: string, field: "created" | "merged" | "updated", page: number): string {
   const params = new URLSearchParams({
     q: query,
-    per_page: "100",
+    per_page: String(SEARCH_PAGE_SIZE),
     page: String(page),
+    sort: searchSort(field),
+    order: "asc",
   });
   return `/search/issues?${params.toString()}`;
+}
+
+function searchSort(field: "created" | "merged" | "updated"): "created" | "updated" {
+  return field === "updated" ? "updated" : "created";
 }
 
 function includeContributor(actor: string, filter: Set<string>): boolean {

--- a/packages/agent-core/src/github/activity.ts
+++ b/packages/agent-core/src/github/activity.ts
@@ -230,7 +230,7 @@ async function fetchRepoEvents(
     try {
       const reviews = await client.getPagedJson<GitHubReview>(
         `${repoPath}/pulls/${pull.number}/reviews?per_page=100`,
-        { maxPages: 1 },
+        { maxPages: null },
       );
 
       for (const review of reviews) {

--- a/packages/agent-core/src/github/activity.ts
+++ b/packages/agent-core/src/github/activity.ts
@@ -192,7 +192,7 @@ async function fetchRepoEvents(
   const openedPulls = await searchPullRequests(client, repo, window, "created", warnings);
   for (const pull of openedPulls) {
     const actor = pull.user?.login ?? "ghost";
-    if (!includeContributor(actor, contributorFilter)) {
+    if (!inWindow(pull.created_at, window) || !includeContributor(actor, contributorFilter)) {
       continue;
     }
 
@@ -211,7 +211,12 @@ async function fetchRepoEvents(
     const actor = pull.user?.login ?? "ghost";
     // GitHub Search exposes merged PR timestamps as closed_at for is:merged queries.
     const mergedAt = pull.closed_at;
-    if (!mergedAt || !includeContributor(actor, contributorFilter)) {
+    if (!mergedAt) {
+      warnings.push(`GitHub search returned merged PR without closed_at for ${repo}#${pull.number}; skipping.`);
+      continue;
+    }
+
+    if (!inWindow(mergedAt, window) || !includeContributor(actor, contributorFilter)) {
       continue;
     }
 
@@ -270,8 +275,8 @@ async function searchPullRequests(
     client,
     repo,
     field,
-    Date.parse(window.from),
-    Date.parse(window.to),
+    floorToSecond(window.from),
+    ceilToSecond(window.to),
     warnings,
   );
 
@@ -287,37 +292,39 @@ async function searchPullRequestsRange(
   client: GitHubClient,
   repo: string,
   field: "created" | "merged" | "updated",
-  fromMs: number,
-  toMs: number,
+  fromSecond: number,
+  toSecond: number,
   warnings: string[],
 ): Promise<GitHubSearchPullRequest[]> {
-  const query = buildPullRequestSearchQuery(repo, field, fromMs, toMs);
+  const query = buildPullRequestSearchQuery(repo, field, fromSecond, toSecond);
   const firstPage = await client.getJson<GitHubSearchResult<GitHubSearchPullRequest>>(searchIssuesPath(query, field, 1));
 
   if (firstPage.total_count > SEARCH_RESULT_LIMIT) {
-    if (fromMs >= toMs) {
+    if (fromSecond >= toSecond) {
       warnings.push(
-        `GitHub search exceeded ${SEARCH_RESULT_LIMIT} PRs for ${repo} (${field}) within a 1ms slice; only the first ${SEARCH_PAGE_SIZE} results were returned.`,
+        `GitHub search exceeded ${SEARCH_RESULT_LIMIT} PRs for ${repo} (${field}) within a 1s slice; only the first ${SEARCH_PAGE_SIZE} results were returned.`,
       );
       return firstPage.items;
     }
 
-    const midpoint = Math.floor((fromMs + toMs) / 2);
+    const midpoint = Math.floor((fromSecond + toSecond) / 2);
     // firstPage.items span the full range and cannot be assigned to a child slice without duplication.
-    const left = await searchPullRequestsRange(client, repo, field, fromMs, midpoint, warnings);
-    const right = await searchPullRequestsRange(client, repo, field, midpoint + 1, toMs, warnings);
+    const left = await searchPullRequestsRange(client, repo, field, fromSecond, midpoint, warnings);
+    const right = await searchPullRequestsRange(client, repo, field, midpoint + 1, toSecond, warnings);
     return [...left, ...right];
   }
 
-  if (firstPage.incomplete_results) {
-    warnings.push(`GitHub search returned incomplete PR results for ${repo} (${field}).`);
-  }
-
+  let incompleteResults = firstPage.incomplete_results;
   const pulls = [...firstPage.items];
-  const totalPages = Math.min(SEARCH_RESULT_LIMIT / SEARCH_PAGE_SIZE, Math.ceil(firstPage.total_count / SEARCH_PAGE_SIZE));
+  const totalPages = Math.ceil(firstPage.total_count / SEARCH_PAGE_SIZE);
   for (let page = 2; page <= totalPages; page += 1) {
     const response = await client.getJson<GitHubSearchResult<GitHubSearchPullRequest>>(searchIssuesPath(query, field, page));
+    incompleteResults ||= response.incomplete_results;
     pulls.push(...response.items);
+  }
+
+  if (incompleteResults) {
+    warnings.push(`GitHub search returned incomplete PR results for ${repo} (${field}).`);
   }
 
   return pulls;
@@ -326,14 +333,14 @@ async function searchPullRequestsRange(
 function buildPullRequestSearchQuery(
   repo: string,
   field: "created" | "merged" | "updated",
-  fromMs: number,
-  toMs: number,
+  fromSecond: number,
+  toSecond: number,
 ): string {
   const parts = [`repo:${repo}`, "is:pr"];
   if (field === "merged") {
     parts.push("is:merged");
   }
-  parts.push(`${field}:${new Date(fromMs).toISOString()}..${new Date(toMs).toISOString()}`);
+  parts.push(`${field}:${toSearchTimestamp(fromSecond)}..${toSearchTimestamp(toSecond)}`);
   return parts.join(" ");
 }
 
@@ -349,7 +356,20 @@ function searchIssuesPath(query: string, field: "created" | "merged" | "updated"
 }
 
 function searchSort(field: "created" | "merged" | "updated"): "created" | "updated" {
+  // GitHub Search does not expose merged-date sorting, so merged queries fall back to created ordering.
   return field === "updated" ? "updated" : "created";
+}
+
+function toSearchTimestamp(second: number): string {
+  return new Date(second * 1000).toISOString().replace(".000Z", "Z");
+}
+
+function floorToSecond(value: string): number {
+  return Math.floor(Date.parse(value) / 1000);
+}
+
+function ceilToSecond(value: string): number {
+  return Math.ceil(Date.parse(value) / 1000);
 }
 
 function includeContributor(actor: string, filter: Set<string>): boolean {

--- a/packages/agent-core/src/github/client.test.ts
+++ b/packages/agent-core/src/github/client.test.ts
@@ -63,6 +63,55 @@ describe("GitHubClient", () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
   });
 
+  test("preserves explicit null maxPages as unlimited pagination", async () => {
+    globalThis.fetch = mock(async (input) => {
+      const url = String(input);
+
+      if (url.endsWith("page=1")) {
+        return new Response(JSON.stringify([{ id: 1 }]), {
+          headers: {
+            "content-type": "application/json",
+            link: '<https://api.github.com/items?page=2>; rel="next"',
+          },
+        });
+      }
+
+      if (url.endsWith("page=2")) {
+        return new Response(JSON.stringify([{ id: 2 }]), {
+          headers: {
+            "content-type": "application/json",
+            link: '<https://api.github.com/items?page=3>; rel="next"',
+          },
+        });
+      }
+
+      if (url.endsWith("page=3")) {
+        return new Response(JSON.stringify([{ id: 3 }]), {
+          headers: {
+            "content-type": "application/json",
+            link: '<https://api.github.com/items?page=4>; rel="next"',
+          },
+        });
+      }
+
+      if (url.endsWith("page=4")) {
+        return new Response(JSON.stringify([{ id: 4 }]), {
+          headers: {
+            "content-type": "application/json",
+          },
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const client = new GitHubClient({ baseUrl: "https://api.github.com" });
+    const items = await client.getPagedJson<{ id: number }>("/items?page=1", { maxPages: null });
+
+    expect(items).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(4);
+  });
+
   test("converts aborted fetches into timeout GitHubError", async () => {
     globalThis.fetch = mock(
       (_input, init) =>

--- a/packages/agent-core/src/github/client.ts
+++ b/packages/agent-core/src/github/client.ts
@@ -47,13 +47,13 @@ export class GitHubClient {
     return (await response.json()) as T;
   }
 
-  async getPagedJson<T>(path: string, options: { maxPages?: number } = {}): Promise<T[]> {
+  async getPagedJson<T>(path: string, options: { maxPages?: number | null } = {}): Promise<T[]> {
     const maxPages = options.maxPages ?? 3;
     const items: T[] = [];
     let pageCount = 0;
     let nextPath: string | null = path;
 
-    while (nextPath && pageCount < maxPages) {
+    while (nextPath && (maxPages === null || pageCount < maxPages)) {
       const response = await this.request(nextPath);
 
       if (!response.ok) {

--- a/packages/agent-core/src/github/client.ts
+++ b/packages/agent-core/src/github/client.ts
@@ -48,7 +48,7 @@ export class GitHubClient {
   }
 
   async getPagedJson<T>(path: string, options: { maxPages?: number | null } = {}): Promise<T[]> {
-    const maxPages = options.maxPages ?? 3;
+    const maxPages = options.maxPages === undefined ? 3 : options.maxPages;
     const items: T[] = [];
     let pageCount = 0;
     let nextPath: string | null = path;

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -27,4 +27,14 @@ describe("schemas", () => {
 
     expect(() => ScopeSchema.parse(scope)).not.toThrow();
   });
+
+  test("rejects repo values that are not owner slash repo slugs", () => {
+    expect(() => {
+      ScopeSchema.parse({
+        repos: ["misty-step/gitpulse is:issue"],
+        orgs: [],
+        contributors: [],
+      });
+    }).toThrow("repo must use owner/repo format");
+  });
 });

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
 export const IsoDateTimeSchema = z.string().datetime({ offset: true });
+const GitHubRepoSlugSchema = z.string().regex(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/, {
+  message: "repo must use owner/repo format",
+});
 
 export const TimeWindowSchema = z
   .object({
@@ -13,7 +16,7 @@ export const TimeWindowSchema = z
   });
 
 export const ScopeSchema = z.object({
-  repos: z.array(z.string().min(1)).default([]),
+  repos: z.array(GitHubRepoSlugSchema).default([]),
   orgs: z.array(z.string().min(1)).default([]),
   contributors: z.array(z.string().min(1)).default([]),
 });


### PR DESCRIPTION
**Summary**
Fixes window coverage in the GitHub activity collector so PR opened, merged, and review metrics are derived from window-correct queries instead of the first two pages of recently updated PRs. The collector now uses GitHub search slices scoped to the requested window, validates repo slugs before building search qualifiers, and pages review results so large PRs do not truncate after the first 100 reviews. Closes #162.

**Intent Reference**
Source issue: https://github.com/misty-step/gitpulse/issues/162
Derived intent contract summary from the issue problem statement and acceptance criteria: collect PR opened, PR merged, and review activity for the exact requested time window even in busy repositories; keep execution bounded; keep metrics deterministic and backed by tests.

**Changes**
- Replace recent-PR pagination in `fetchRepoEvents` with window-first GitHub search queries for `created`, `merged`, and `updated` PR slices.
- Add deterministic search ordering and serialize recursive search splitting so large windows stay bounded without recursive request bursts.
- Validate scope repo values as `owner/repo` slugs before composing GitHub search qualifiers.
- Page PR reviews across all available review pages instead of truncating after the first 100 reviews.
- Add regression tests for multi-page search pagination, recursive split + dedupe behavior, leaf-only incomplete-result warnings, and multi-page review collection.
- Add `.groom/retro.md` so the workflow-owned retro artifact exists in-repo.

**Acceptance Criteria**
- [x] PR opened/merged metrics are window-correct for busy repositories.
- [x] Review metrics do not depend on the first N candidate PRs.
- [x] The collector remains bounded and tested.

**Manual QA**
1. Run `bun run test`.
Expected: all workspace tests pass, including `packages/agent-core/src/github/activity.test.ts` and `packages/schemas/src/index.test.ts`.
2. Run `bun run typecheck`.
Expected: workspace typecheck passes.
3. Run `bun run build`.
Expected: CLI, agent-core, schemas, and Next.js web app build successfully.
4. Inspect `packages/agent-core/src/github/activity.ts`.
Expected: PR opened, merged, and review collection use `/search/issues` window queries, recursive split is serialized, and review pagination is no longer capped at one page.

**What Changed**
```mermaid
graph TD
  A[fetchActivityWindow] --> B[fetchRepoEvents]
  B --> C[search created window]
  B --> D[search merged window]
  B --> E[search updated window]
  E --> F[page all review results]
  C --> G[pull_request_opened events]
  D --> H[pull_request_merged events]
  F --> I[pull_request_reviewed events]
  J[ScopeSchema] --> K[validate owner/repo slug]
```

**Before / After**
Before: PR opened and merged coverage depended on the first two pages of recently updated PRs, review coverage only considered that truncated PR set, and large PRs still dropped reviews after the first 100 results.
After: PR opened, merged, and review coverage are derived from window-scoped searches, recursive splits are deterministic and serialized, repo qualifiers are validated up front, and PR reviews are paged across all review pages.

**Test Coverage**
- `packages/agent-core/src/github/activity.test.ts`
- `packages/agent-core/src/github/client.test.ts`
- `packages/schemas/src/index.test.ts`
- Full workspace verification via `bun run test`, `bun run typecheck`, and `bun run build`
Gaps: no live GitHub API integration test in CI; coverage remains mock-based at the collector boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved PR event collection via search-based queries with better time-window accuracy, multi-page handling, deduplication, and warnings for oversized windows.
  * Pagination option now supports unlimited paging when explicitly enabled.

* **Documentation**
  * Added a retro log template and guidance for recording retros.

* **Tests**
  * Expanded tests for search-based PR flows, paging, deduplication, unlimited pagination, and invalid repo input.

* **Chores**
  * Enforced owner/repo format for repo inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->